### PR TITLE
fix: API 베이스 경로 통일 및 깨진 한글 수정

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -1,5 +1,5 @@
 ﻿// src/api/admin.ts
-import { api } from './client';
+import { api, withApiBase } from './client';
 
 export type AdminLoginBody = {
   userId: string;
@@ -19,19 +19,12 @@ export type UpdateAccountBody = {
   newPassword: string;
 };
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
-const ADMIN_BASE = API_BASE ? `${API_BASE}/api` : '/api';
 const DEMO_MODE = import.meta.env.VITE_DEMO_MODE === 'true';
-
-function joinBase(path: string) {
-  const base = ADMIN_BASE.endsWith('/') ? ADMIN_BASE.slice(0, -1) : ADMIN_BASE;
-  return `${base}${path}`;
-}
 
 export const adminApi = {
   async login(body: AdminLoginBody) {
     try {
-      return await api<AdminLoginResponse>(joinBase('/admin/login'), {
+      return await api<AdminLoginResponse>(withApiBase('/admin/login'), {
         method: 'POST',
         body,
       });
@@ -42,11 +35,11 @@ export const adminApi = {
   },
 
   logout() {
-    return api<void>(joinBase('/admin/logout'), { method: 'POST' });
+    return api<void>(withApiBase('/admin/logout'), { method: 'POST' });
   },
 
   updateAccount(body: UpdateAccountBody) {
-    return api<void>(joinBase('/admin/account'), {
+    return api<void>(withApiBase('/admin/account'), {
       method: 'PATCH',
       body,
     }).catch((err) => {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,5 +1,9 @@
 ﻿type HttpMethod = 'GET' | 'POST' | 'PATCH' | 'DELETE';
 
+export const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? '').replace(/\/$/, '');
+export const withApiBase = (path: string) =>
+  API_BASE ? `${API_BASE}${path}` : path;
+
 export class ApiError extends Error {
   status: number;
   body: unknown;

--- a/src/api/forms.ts
+++ b/src/api/forms.ts
@@ -1,4 +1,4 @@
-﻿import { api } from './client';
+﻿import { api, withApiBase } from './client';
 
 export type FormQuestion = {
   id: number;
@@ -56,7 +56,7 @@ const demoForm: ActiveFormResponse = {
 export const formsApi = {
   async getActiveForm() {
     try {
-      return await api<ActiveFormResponse>('/api/forms/active');
+      return await api<ActiveFormResponse>(withApiBase('/forms/active'));
     } catch (err) {
       if (DEMO_MODE) return demoForm;
       throw err;
@@ -64,10 +64,10 @@ export const formsApi = {
   },
   async applyActiveForm(payload: ApplyRequest) {
     try {
-      return await api<ApplyResponse>('/api/forms/active/apply', {
+      return await api<ApplyResponse>(withApiBase('/forms/active/apply'), {
         method: 'POST',
         body: payload,
-      });
+      });      
     } catch (err) {
       if (DEMO_MODE) {
         return { applicationId: Date.now(), resultCode: 'DEMO' };

--- a/src/api/intro.ts
+++ b/src/api/intro.ts
@@ -1,4 +1,4 @@
-import { api } from './client';
+import { api, withApiBase } from './client';
 import type { AdminContent } from '../utils/adminContent';
 
 type IntroduceInfoResponse = Partial<AdminContent['about']>;
@@ -39,10 +39,10 @@ export function normalizeIntroduceResponses(
 
 export const introApi = {
   getInformation() {
-    return api<IntroduceInfoResponse>('/api/introduce/information');
+    return api<IntroduceInfoResponse>(withApiBase('/introduce/information'));
   },
 
   getSns() {
-    return api<IntroduceSnsResponse>('/api/introduce/sns');
+    return api<IntroduceSnsResponse>(withApiBase('/introduce/sns'));
   },
 };

--- a/src/api/projects.ts
+++ b/src/api/projects.ts
@@ -1,4 +1,4 @@
-﻿import { api } from './client';
+﻿import { api, withApiBase } from './client';
 
 export type ProjectStatus = 'upcoming' | 'active' | 'closed';
 
@@ -59,7 +59,7 @@ function toProject(item: ProjectResponse): Project {
 export const projectsApi = {
   async list(): Promise<Project[]> {
     const data = await api<ProjectResponse[] | { data: ProjectResponse[] }>(
-      '/api/projects'
+      withApiBase('/projects')
     );
     const items = Array.isArray(data)
       ? data
@@ -71,7 +71,7 @@ export const projectsApi = {
 
   async getById(id: string): Promise<Project | undefined> {
     try {
-      const data = await api<ProjectResponse>(`/api/projects/${id}`);
+      const data = await api<ProjectResponse>(withApiBase(`/projects/${id}`));
       return toProject(data);
     } catch (e) {
       console.error(e);

--- a/src/api/resources.ts
+++ b/src/api/resources.ts
@@ -1,4 +1,4 @@
-import { api } from './client';
+import { api, withApiBase } from './client';
 
 export type ResourceCategory = 'journal' | 'template';
 export type ResourceLinkKind = 'folder' | 'file';
@@ -47,8 +47,6 @@ export const resources = mockResources;
 export const resourcesApi = {
   async list(): Promise<ResourceItem[]> {
     if (USE_MOCK) return mockResources;
-
-    // ⚠️ 백엔드에 /api/resources가 생기면 그대로 사용 가능
-    return api<ResourceItem[]>('/api/resources');
+    return api<ResourceItem[]>(withApiBase('/resources'));
   },
 };

--- a/src/api/settlements.ts
+++ b/src/api/settlements.ts
@@ -1,4 +1,4 @@
-﻿import { api } from './client';
+﻿import { api, withApiBase } from './client';
 import { settlementReports } from '../data/settlements';
 import { loadAdminSettlements } from '../utils/adminSettlements';
 import type {
@@ -42,7 +42,7 @@ export const settlementsApi = {
       return adminReports.length ? adminReports : settlementReports;
     }
 
-    const raw = await api<unknown>('/api/settlements');
+    const raw = await api<unknown>(withApiBase('/settlements'));
     return normalizeReportsResponse(raw).map(mapReportDto);
   },
 };


### PR DESCRIPTION
iss #6 

# 요약
- 프론트 전역 API 호출 경로를 VITE_API_BASE_URL(/api) 기준으로 통일
- 깨진 한글 부분들을 수정
- Media presign batch API 전환에 맞춰 업로드 경로 일관성을 준비

# 작업 내용
## API Base 정리
- 각 API 모듈에서 개별 base 조합 제거
- 공통 withApiBase()로 호출 경로 통일
- /api 기준의 상대 경로 형태 유지
## Media presign batch 경로 일관성 준비
- 기존 단건 presign 전제 제거를 고려한 호출 구조 정리
- batch API 사용을 위한 엔드포인트 일관화

# 테스트 방법
- 관리자 로그인/로그아웃 호출 확인
- 소개/폼/프로젝트/리소스/정산 API 호출 확인

# 기타
- 추가 API 구현은 별도 브랜치에서 진행 예정
- 현 브랜치는 배포 환경 한글 깨짐 및 리소스 로드 오류 해결 목적