### PR TITLE
Fix: 플로팅 SNS 아이콘 이미지 경로 수정

### DIFF
--- a/src/components/FloatingSns.tsx
+++ b/src/components/FloatingSns.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 import { introApi, type IntroduceSnsItem } from '../api/intro';
+import instagramLogo from '../assets/logos/instagram.png';
+import kakaoLogo from '../assets/logos/kakao.png';
 
 function toSnsKind(value?: string) {
   const v = (value ?? '').toLowerCase();
@@ -39,7 +41,7 @@ export default function FloatingSns() {
         aria-label="Instagram"
       >
         <img
-          src="/src/assets/logos/instagram.png"
+          src={instagramLogo}
           alt="Instagram"
           className="h-full w-full rounded-full object-cover"
         />
@@ -54,7 +56,7 @@ export default function FloatingSns() {
         aria-label="KakaoTalk"
       >
         <img
-          src="/src/assets/logos/kakao.png"
+          src={kakaoLogo}
           alt="KakaoTalk"
           className="h-full w-full object-cover"
         />


### PR DESCRIPTION
#10 

# 요약
- 배포 환경에서 플로팅 SNS 아이콘이 보이지 않던 오류 수정

# 작업 내용
- 아이콘 이미지 경로를 import 형식으로 수정
- 플로팅 SNS UI는 기존 그대로 유지

# 테스트 방법
- 배포/로컬에서 플로팅 아이콘 정상 노출 확인
