### PR TITLE
Fix: Footer 하단 고정 및 Footer 문구 수정

### DIFF
--- a/src/components/SiteLayout.tsx
+++ b/src/components/SiteLayout.tsx
@@ -3,9 +3,9 @@ import Header from './Header';
 
 export default function SiteLayout() {
   return (
-    <div className="min-h-screen bg-app-bg text-slate-900 font-body">
+    <div className="min-h-screen flex flex-col bg-app-bg text-slate-900 font-body">
       <Header />
-      <main className="pt-16">
+      <main className="flex-1 pt-16">
         <Outlet />
       </main>
 
@@ -16,7 +16,7 @@ export default function SiteLayout() {
             제작: 명지대학교 IT 서비스 개발 중앙 동아리 COW
           </div>
           <div className="mt-1">
-            © {new Date().getFullYear()} Myongji Workshop
+            © {new Date().getFullYear()} MJU Craft Studio
           </div>
         </div>
       </footer>


### PR DESCRIPTION
#12 

# 요약
- 화면 높이에 따라 Footer가 떠 보이던 문제 → 하단 고정으로 수정
- Footer 문구 'MJU Craft Studio'로 변경

# 작업 내용
- SiteLayout 루트에 flex 레이아웃 적용
- main 영역에 flex-1 적용해 Footer 하단 고정
- Footer 표기명 변경

# 테스트 방법
- 메인/소개 페이지에서 화면 높이별 Footer 위치 확인
