### PR TITLE
Fix: 플로팅 SNS 인스타/카카오 링크 연동 및 UI 보완

### DIFF
--- a/src/api/sns.ts
+++ b/src/api/sns.ts
@@ -1,0 +1,42 @@
+import { ApiError, api, withApiBase } from './client';
+
+export type SnsLink = {
+  type?: string;
+  url?: string;
+  title?: string;
+};
+
+function unwrapApiData<T>(raw: unknown): T | undefined {
+  if (!raw) return undefined;
+  if (typeof raw === 'object') {
+    const record = raw as Record<string, unknown>;
+    if ('data' in record) return record.data as T;
+  }
+  return raw as T;
+}
+
+function safeGet<T>(promise: Promise<T>) {
+  return promise.catch((err) => {
+    if (err instanceof ApiError && err.status === 404) {
+      return null as T;
+    }
+    throw err;
+  });
+}
+
+export const snsApi = {
+  getInstagram() {
+    return safeGet(
+      api<unknown>(withApiBase('/sns/instagram')).then((raw) =>
+        unwrapApiData<SnsLink>(raw)
+      )
+    );
+  },
+  getKakao() {
+    return safeGet(
+      api<unknown>(withApiBase('/sns/kakao')).then((raw) =>
+        unwrapApiData<SnsLink>(raw)
+      )
+    );
+  },
+};

--- a/src/components/FloatingSns.tsx
+++ b/src/components/FloatingSns.tsx
@@ -1,74 +1,73 @@
 import { useEffect, useState } from 'react';
-import { introApi, type IntroduceSnsItem } from '../api/intro';
+import { snsApi } from '../api/sns';
 import instagramLogo from '../assets/logos/instagram.png';
 import kakaoLogo from '../assets/logos/kakao.png';
 
-function toSnsKind(value?: string) {
-  const v = (value ?? '').toLowerCase();
-  if (v.includes('insta')) return 'instagram';
-  if (v.includes('kakao')) return 'kakao';
-  return 'link';
-}
-
 export default function FloatingSns() {
-  const [snsLinks, setSnsLinks] = useState<IntroduceSnsItem[]>([]);
+  const [instagramUrl, setInstagramUrl] = useState<string | null>(null);
+  const [kakaoUrl, setKakaoUrl] = useState<string | null>(null);
 
   useEffect(() => {
-    introApi
-      .getSns()
-      .then((data) => {
-        const list = Array.isArray(data) ? data : [];
-        const sorted = list
-          .filter((item) => item && (item.active ?? true))
-          .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
-        setSnsLinks(sorted);
+    let active = true;
+    Promise.allSettled([snsApi.getInstagram(), snsApi.getKakao()])
+      .then(([instagramResult, kakaoResult]) => {
+        if (!active) return;
+        const instagram =
+          instagramResult.status === 'fulfilled'
+            ? instagramResult.value
+            : null;
+        const kakao =
+          kakaoResult.status === 'fulfilled' ? kakaoResult.value : null;
+        setInstagramUrl(instagram?.url ?? null);
+        setKakaoUrl(kakao?.url ?? null);
       })
-      .catch(() => setSnsLinks([]));
-  }, []);
+      .catch(() => {
+        if (!active) return;
+        setInstagramUrl(null);
+        setKakaoUrl(null);
+      });
 
-  const instagram = snsLinks.find((l) => toSnsKind(l.iconKey ?? l.type) === 'instagram');
-// const kakao = snsLinks.find((l) => toSnsKind(l.iconKey ?? l.type) === 'kakao');
+    return () => {
+      active = false;
+    };
+  }, []);
 
   return (
     <div className="fixed bottom-6 right-6 z-50 flex flex-col items-end gap-3">
-      {/* 인스타그램 아이콘 */}
-      {instagram?.url && (
+      {instagramUrl && (
         <a
-        href={instagram.url}
-        target="_blank"
-        rel="noreferrer"
-        className="h-15 w-15 overflow-hidden rounded-full shadow-lg"
-        aria-label="Instagram"
-      >
-        <img
-          src={instagramLogo}
-          alt="Instagram"
-          className="h-full w-full rounded-full object-cover"
-        />
-      </a>
-      
+          href={instagramUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="h-13 w-13 overflow-hidden rounded-full shadow-lg"
+          aria-label="Instagram">
+          <img
+            src={instagramLogo}
+            alt="Instagram"
+            className="h-full w-full rounded-full object-cover"/>
+        </a>
       )}
-  
-      {/* 카카오톡 아이콘 (링크는 아직 없음) */}
-      <button
-        type="button"
-        className="h-15 w-15 overflow-hidden border border-slate-200  rounded-full shadow-lg"
-        aria-label="KakaoTalk"
-      >
-        <img
-          src={kakaoLogo}
-          alt="KakaoTalk"
-          className="h-full w-full object-cover"
-        />
-      </button>
-  
-      {/* TOP 버튼 */}
+
+      {kakaoUrl && (
+        <a
+          href={kakaoUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="h-13 w-13 overflow-hidden rounded-full shadow-lg"
+          aria-label="Kakao">
+          <img
+            src={kakaoLogo}
+            alt="Kakao"
+            className="h-full w-full object-cover"/>
+        </a>
+      )}
+
       <button
         type="button"
         onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-        className="h-15 w-15 rounded-full bg-[#002968] text-sm font-bold text-white shadow-lg">
+        className="h-13 w-13 rounded-full bg-[#002968] text-sm font-bold text-white shadow-lg">
         TOP
       </button>
     </div>
-  );  
+  );
 }


### PR DESCRIPTION
#18 

# 작업 내용
- 공개 SNS API(/api/sns/instagram, /api/sns/kakao) 연동으로 플로팅 버튼 링크 연결
- SNS 응답 구조 정규화 처리 및 404일 때 무시
- 플로팅 아이콘 UI 크기/스타일 보완

# 테스트 방법
- Swagger에서 관리자 인증 후 SNS 링크 등록
- 로컬 실행 후 플로팅 인스타/카카오 버튼 클릭 시 각각 링크 이동 확인

# 비고
- SNS 링크가 미등록이면 버튼이 표시되지 않음