### PR TITLE
Feat: CONTACT feedback API 연동 및 입력 검증/반응형 UI 구현

### DIFF
--- a/src/api/feedback.ts
+++ b/src/api/feedback.ts
@@ -1,0 +1,21 @@
+// src/api/feedback.ts
+import { api, withApiBase } from './client';
+
+export type CreateFeedbackBody = {
+  isStudent: boolean;
+  message: string;
+};
+
+export type CreateFeedbackResponse = {
+  id?: string;
+  message?: string;
+};
+
+export const feedbackApi = {
+  create(body: CreateFeedbackBody) {
+    return api<CreateFeedbackResponse>(withApiBase('/feedback'), {
+      method: 'POST',
+      body,
+    });
+  },
+};

--- a/src/pages/site/ContactPage.tsx
+++ b/src/pages/site/ContactPage.tsx
@@ -1,133 +1,254 @@
-import { useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
+import { api, ApiError, withApiBase } from '../../api/client';
 import Reveal from '../../components/Reveal';
-import BrandIcon from '../../components/BrandIcon';
-import { addFeedbackEntry } from '../../utils/feedbackStore';
-import { loadAdminContent } from '../../utils/adminContent';
+
+type SubmitStatus = 'idle' | 'submitting' | 'success' | 'error';
+
+const TITLE_MAX = 50;
+const CONTENT_MAX = 1000;
 
 export default function ContactPage() {
-  const content = useMemo(() => loadAdminContent(), []);
-  const [isStudent, setIsStudent] = useState('');
-  const [message, setMessage] = useState('');
-  const [submitted, setSubmitted] = useState(false);
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+
+  const [status, setStatus] = useState<SubmitStatus>('idle');
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const [titleLimitHit, setTitleLimitHit] = useState(false);
+  const [contentLimitHit, setContentLimitHit] = useState(false);
+
+  const successMsg = useMemo(() => '건의사항이 등록됐어요. 감사합니다!', []);
+
+  const validate = () => {
+    const t = title.trim();
+    const c = content.trim();
+
+    if (!t) return '제목을 입력해 주세요.';
+    if (!c) return '내용을 입력해 주세요.';
+
+    if (t.length > TITLE_MAX) return `제목은 ${TITLE_MAX}자 이내로 입력해 주세요.`;
+    if (c.length > CONTENT_MAX) return `내용은 ${CONTENT_MAX}자 이내로 입력해 주세요.`;
+
+    return null;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    // submitting 중 중복 submit 방지 (모바일에서 더 유용)
+    if (status === 'submitting') return;
+
+    const validationError = validate();
+    if (validationError) {
+      setStatus('error');
+      setErrorMsg(validationError);
+      return;
+    }
+
+    setStatus('submitting');
+    setErrorMsg(null);
+
+    try {
+      await api<void>(withApiBase('/feedback'), {
+        method: 'POST',
+        body: {
+          title: title.trim(),
+          content: content.trim(),
+        },
+      });
+
+      setStatus('success');
+      setTitle('');
+      setContent('');
+      setTitleLimitHit(false);
+      setContentLimitHit(false);
+    } catch (err) {
+      let msg = '등록에 실패했어요. 잠시 후 다시 시도해 주세요.';
+
+      if (err instanceof ApiError) {
+        msg = err.message || msg;
+
+        if (err.status === 401 || err.status === 403) {
+          msg = '로그인이 필요해요. 로그인 후 다시 시도해 주세요.';
+        }
+      }
+
+      setStatus('error');
+      setErrorMsg(msg);
+    }
+  };
+
+  const clearGlobalMessageIfNeeded = () => {
+    if (status === 'error' || status === 'success') {
+      setStatus('idle');
+      setErrorMsg(null);
+    }
+  };
+
+  const flashTitleLimit = () => {
+    setTitleLimitHit(true);
+    window.setTimeout(() => setTitleLimitHit(false), 1500);
+  };
+
+  const flashContentLimit = () => {
+    setContentLimitHit(true);
+    window.setTimeout(() => setContentLimitHit(false), 1500);
+  };
+
+  const onChangeTitle = (v: string) => {
+    clearGlobalMessageIfNeeded();
+
+    if (v.length <= TITLE_MAX) {
+      setTitle(v);
+      setTitleLimitHit(false);
+      return;
+    }
+
+    setTitle(v.slice(0, TITLE_MAX));
+    flashTitleLimit();
+  };
+
+  const onChangeContent = (v: string) => {
+    clearGlobalMessageIfNeeded();
+
+    if (v.length <= CONTENT_MAX) {
+      setContent(v);
+      setContentLimitHit(false);
+      return;
+    }
+
+    setContent(v.slice(0, CONTENT_MAX));
+    flashContentLimit();
+  };
+
+  const isSubmitting = status === 'submitting';
+
+  const titleErrorText =
+    titleLimitHit ? `제목은 최대 ${TITLE_MAX}자까지 입력할 수 있어요.` : null;
+
+  const contentErrorText =
+    contentLimitHit ? `내용은 최대 ${CONTENT_MAX}자까지 입력할 수 있어요.` : null;
+
+  const inputBase =
+    'mt-2 w-full rounded-2xl border px-4 py-3 text-sm outline-none transition disabled:bg-slate-50';
+
+  const focusRing = 'focus:ring-4 focus:ring-primary/10';
+  const focusBorderOk = 'border-slate-200 focus:border-primary/60';
+  const focusBorderErr = 'border-rose-300 focus:border-rose-400 focus:ring-rose-100';
 
   return (
-    <div className="mx-auto max-w-6xl px-4 py-12">
+    <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 sm:py-12">
       <Reveal>
-        <h1 className="font-heading text-3xl text-primary">문의</h1>
-        <p className="mt-2 text-slate-600">
-          링크트리 정보를 한 곳에 모으고, 피드백을 제출할 수 있어요.
+        <h1 className="font-heading text-2xl text-primary sm:text-3xl">CONTACT</h1>
+        <p className="mt-2 text-sm text-slate-600 sm:text-base">
+          더 나은 서비스를 위해 피드백을 제출해주세요!
         </p>
-      </Reveal>
-
-      <Reveal delayMs={80} className="mt-8 rounded-3xl bg-white p-8">
-        <h2 className="font-heading text-xl text-slate-900">바로가기</h2>
-        <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2">
-          {content.linktree.filter((item) => item.url.trim().length > 0)
-            .length === 0 ? (
-            <div className="rounded-2xl border border-slate-200 bg-white p-4 text-sm text-slate-500">
-              등록된 링크가 없어요.
-            </div>
-          ) : (
-            content.linktree
-              .filter((item) => item.url.trim().length > 0)
-              .map((item) => (
-                <a
-                  key={item.id}
-                  href={item.url}
-                  target={item.url.startsWith('/') ? undefined : '_blank'}
-                  rel={item.url.startsWith('/') ? undefined : 'noreferrer'}
-                  className="flex items-center gap-3 rounded-2xl border border-slate-200 px-4 py-4 text-sm font-bold text-slate-700 hover:bg-slate-50"
-                >
-                  <BrandIcon kind={item.kind} />
-                  <div>
-                    <div>{item.title}</div>
-                    {item.description && (
-                      <div className="mt-1 text-xs font-normal text-slate-500">
-                        {item.description}
-                      </div>
-                    )}
-                  </div>
-                </a>
-              ))
-          )}
-        </div>
       </Reveal>
 
       <Reveal
         id="feedback"
         delayMs={120}
-        className="mt-10 rounded-3xl bg-white p-8"
+        className="mt-8 rounded-3xl bg-white p-5 shadow-sm ring-1 ring-slate-100 sm:mt-10 sm:p-8"
       >
-        <h2 className="font-heading text-xl text-slate-900">피드백 제출 폼</h2>
-        <p className="mt-2 text-sm text-slate-600">
-          명지공방에게 전하고 싶은 이야기를 들려주세요.
-        </p>
-
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            if (!isStudent || !message.trim()) return;
-            addFeedbackEntry({ isStudent, message: message.trim() });
-            setSubmitted(true);
-            setMessage('');
-          }}
-          className="mt-6 space-y-5"
-        >
+        {/* 헤더: 모바일은 세로, sm 이상은 가로 정렬 */}
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <div className="text-sm font-bold text-slate-700">
-              {content.feedbackForm.question1}
-            </div>
-            <div className="mt-3 flex flex-wrap gap-2">
-              {content.feedbackForm.question1Options.map((opt) => (
-                <button
-                  type="button"
-                  key={opt}
-                  onClick={() => {
-                    setIsStudent(opt);
-                    if (submitted) setSubmitted(false);
-                  }}
-                  className={[
-                    'rounded-full border px-4 py-2 text-sm font-bold transition-colors',
-                    isStudent === opt
-                      ? 'border-primary bg-primary text-white'
-                      : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50',
-                  ].join(' ')}
-                >
-                  {opt}
-                </button>
-              ))}
+            <h2 className="font-heading text-lg text-slate-900 sm:text-xl">
+              피드백 제출 폼
+            </h2>
+            <p className="mt-2 text-sm text-slate-600">
+              명지공방에게 전하고 싶은 이야기를 들려주세요.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-2 sm:justify-end">
+            {status === 'success' && (
+              <span className="rounded-full bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-700 ring-1 ring-emerald-100">
+                제출 완료
+              </span>
+            )}
+            {status === 'error' && (
+              <span className="rounded-full bg-rose-50 px-3 py-1 text-xs font-medium text-rose-700 ring-1 ring-rose-100">
+                확인 필요
+              </span>
+            )}
+          </div>
+        </div>
+
+        <form onSubmit={handleSubmit} className="mt-6 space-y-5">
+          {/* 제목 */}
+          <div>
+            <label className="text-sm font-medium text-slate-900">제목</label>
+            <input
+              value={title}
+              onChange={(e) => onChangeTitle(e.target.value)}
+              disabled={isSubmitting}
+              placeholder="예) 예약 화면 개선 요청"
+              className={[
+                inputBase,
+                focusRing,
+                titleLimitHit ? focusBorderErr : focusBorderOk,
+              ].join(' ')}
+            />
+
+            <div className="mt-1 flex items-start justify-between gap-3">
+              <p className="text-xs text-rose-600">{titleErrorText ?? ''}</p>
+              <p className="text-xs text-slate-400">
+                {title.length}/{TITLE_MAX}
+              </p>
             </div>
           </div>
 
-          <label className="block">
-            <div className="text-sm font-bold text-slate-700">
-              {content.feedbackForm.question2}
-            </div>
+          {/* 내용 */}
+          <div>
+            <label className="text-sm font-medium text-slate-900">내용</label>
             <textarea
-              value={message}
-              onChange={(e) => {
-                setMessage(e.target.value);
-                if (submitted) setSubmitted(false);
-              }}
-              rows={5}
-              required
-              className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none focus:border-primary/60"
-              placeholder="자유롭게 작성해주세요."
+              value={content}
+              onChange={(e) => onChangeContent(e.target.value)}
+              disabled={isSubmitting}
+              placeholder="예) 예약 가능한 날짜를 달력으로 보여주면 좋겠습니다."
+              rows={6}
+              className={[
+                inputBase,
+                'resize-y',
+                'min-h-[160px] sm:min-h-[220px]', // ✅ 모바일/데스크탑 높이 차등
+                focusRing,
+                contentLimitHit ? focusBorderErr : focusBorderOk,
+              ].join(' ')}
             />
-          </label>
 
-          <button
-            type="submit"
-            className="rounded-xl bg-primary px-5 py-3 text-sm font-bold text-white"
-          >
-            제출하기
-          </button>
-
-          {submitted && (
-            <div className="rounded-2xl bg-primary/10 p-4 text-sm font-bold text-primary">
-              제출이 완료되었습니다. 소중한 의견 감사합니다.
+            <div className="mt-1 flex items-start justify-between gap-3">
+              <p className="text-xs text-rose-600">{contentErrorText ?? ''}</p>
+              <p className="text-xs text-slate-400">
+                {content.length}/{CONTENT_MAX}
+              </p>
             </div>
-          )}
+          </div>
+
+          {/* 성공/실패 메시지 (제출 결과) */}
+          <div className="min-h-[22px]">
+            {status === 'success' && (
+              <p className="text-sm text-emerald-600">{successMsg}</p>
+            )}
+            {status === 'error' && errorMsg && (
+              <p className="text-sm text-rose-600">{errorMsg}</p>
+            )}
+          </div>
+
+          {/* 버튼: 모바일 full width / sm 이상 auto */}
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-xs leading-relaxed text-slate-500 sm:max-w-[70%]">
+              제출된 피드백은 내부 검토 후 서비스 개선에 반영될 수 있어요.
+            </p>
+
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="inline-flex h-11 w-full items-center justify-center rounded-2xl bg-primary px-5 text-sm font-semibold text-white shadow-sm transition hover:opacity-95 focus:outline-none focus:ring-4 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+            >
+              {isSubmitting ? '전송 중...' : '전송하기'}
+            </button>
+          </div>
         </form>
       </Reveal>
     </div>


### PR DESCRIPTION
#20 

# 작업 내용
- CONTACT 페이지에 피드백 등록 API(`/api/feedback`) 연동
- 제목/내용 입력값 검증 및 글자 수 제한(제목 50자, 내용 1000자) 처리
- 입력 제한 초과 시도 시 경고 UI(빨간 테두리/메시지) 노출
- 제출 성공/실패 상태 메시지 및 폼 초기화 처리
- 중복 제출 방지를 위한 제출 중 상태 제어
- 모바일/데스크탑 환경을 고려한 반응형 UI 적용

# 테스트 방법
- 로컬 실행 후 CONTACT 페이지 접속
- 제목/내용 입력 후 전송 버튼 클릭 시 `/api/feedback` POST 요청 정상 여부 확인
- 입력값 미입력/초과 입력 시 검증 메시지 노출 확인
- 정상 제출 시 성공 메시지 표시 및 입력 폼 초기화 확인
- 모바일 화면에서 버튼 full-width 및 레이아웃 정상 동작 확인

# 비고
- 피드백 등록 API는 200/204 응답 모두 정상 처리하도록 구현
- 인증 필요(401/403) 응답 시 로그인 안내 메시지 노출
- 입력 제한 초과 시도 시 값은 차단되며 경고 UI는 일정 시간 후 자동 해제됨
