### PR TITLE
feat: 관리자 SNS 링크 관리 API 연동 및 플로팅 UI 반영

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,6 +1,9 @@
-﻿type HttpMethod = 'GET' | 'POST' | 'PATCH' | 'DELETE';
+﻿type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
-export const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? '').replace(/\/$/, '');
+export const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? '').replace(
+  /\/$/,
+  '',
+);
 export const withApiBase = (path: string) =>
   API_BASE ? `${API_BASE}${path}` : path;
 
@@ -29,7 +32,7 @@ type RequestOptions = {
 
 export async function api<T>(
   path: string,
-  opts: RequestOptions = {}
+  opts: RequestOptions = {},
 ): Promise<T> {
   const method = opts.method ?? 'GET';
 

--- a/src/api/sns.ts
+++ b/src/api/sns.ts
@@ -1,9 +1,13 @@
-import { ApiError, api, withApiBase } from './client';
+import { api, ApiError, withApiBase } from './client';
 
 export type SnsLink = {
   type?: string;
   url?: string;
   title?: string;
+};
+
+export type SnsAdminUpsertBody = {
+  url: string;
 };
 
 function unwrapApiData<T>(raw: unknown): T | undefined {
@@ -28,15 +32,32 @@ export const snsApi = {
   getInstagram() {
     return safeGet(
       api<unknown>(withApiBase('/sns/instagram')).then((raw) =>
-        unwrapApiData<SnsLink>(raw)
-      )
+        unwrapApiData<SnsLink>(raw),
+      ),
     );
   },
   getKakao() {
     return safeGet(
       api<unknown>(withApiBase('/sns/kakao')).then((raw) =>
-        unwrapApiData<SnsLink>(raw)
-      )
+        unwrapApiData<SnsLink>(raw),
+      ),
     );
+  },
+};
+
+// 관리자용
+export const snsAdminApi = {
+  async upsertInstagram(body: SnsAdminUpsertBody) {
+    await api<void>(withApiBase('/admin/sns/instagram'), {
+      method: 'PUT',
+      body,
+    });
+  },
+
+  async upsertKakao(body: SnsAdminUpsertBody) {
+    await api<void>(withApiBase('/admin/sns/kakao'), {
+      method: 'PUT',
+      body,
+    });
   },
 };

--- a/src/pages/admin/sections/AdminLinksSection.tsx
+++ b/src/pages/admin/sections/AdminLinksSection.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useRef } from 'react';
 import Reveal from '../../../components/Reveal';
 import BrandIcon from '../../../components/BrandIcon';
+import { snsApi } from '../../../api/sns';
 import type { AdminContent } from '../../../utils/adminContent';
 
 type Props = {
@@ -8,40 +10,98 @@ type Props = {
 };
 
 export default function AdminLinksSection({ content, updateContent }: Props) {
+  const instagramUrl = content.links.instagramUrl ?? '';
+  const kakaoUrl = content.links.kakaoUrl ?? '';
+
+  const didPrefillRef = useRef(false);
+
+  // 최초 진입 시 서버에 등록된 링크가 있으면 폼에 채워줌(비어있을 때만)
+  useEffect(() => {
+    if (didPrefillRef.current) return;
+
+    const shouldPrefill = !instagramUrl.trim() && !kakaoUrl.trim();
+    if (!shouldPrefill) {
+      didPrefillRef.current = true;
+      return;
+    }
+
+    let active = true;
+
+    Promise.allSettled([snsApi.getInstagram(), snsApi.getKakao()])
+      .then(([igRes, kkRes]) => {
+        if (!active) return;
+
+        const ig = igRes.status === 'fulfilled' ? igRes.value : null;
+        const kk = kkRes.status === 'fulfilled' ? kkRes.value : null;
+
+        if (ig?.url || kk?.url) {
+          updateContent({
+            ...content,
+            links: {
+              ...content.links,
+              instagramUrl: ig?.url ?? '',
+              kakaoUrl: kk?.url ?? '',
+            },
+          });
+        }
+      })
+      .finally(() => {
+        didPrefillRef.current = true;
+      });
+
+    return () => {
+      active = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ✅ 이제 실제로 사용
+  const inputBase =
+    'mt-2 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm outline-none transition focus:border-primary/60';
+
   return (
     <Reveal id="links" delayMs={120} className="mt-10 rounded-3xl bg-white p-8">
       <h2 className="font-heading text-xl text-slate-900">공식 링크</h2>
-      <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
-        <label className="block">
+      <p className="mt-2 text-sm text-slate-600">
+        저장하면 사이트의 플로팅 SNS 버튼 링크가 변경됩니다.
+      </p>
+
+      <div className="mt-6 space-y-5">
+        {/* 인스타그램 */}
+        <div className="rounded-2xl border border-slate-100 bg-slate-50/40 p-4">
           <div className="flex items-center gap-2 text-sm font-bold text-slate-700">
             <BrandIcon kind="instagram" /> 인스타그램 URL
           </div>
           <input
-            value={content.links.instagramUrl}
+            value={instagramUrl}
             onChange={(e) =>
               updateContent({
                 ...content,
                 links: { ...content.links, instagramUrl: e.target.value },
               })
             }
-            className="mt-2 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm outline-none focus:border-primary/60"
+            placeholder="https://instagram.com/..."
+            className={inputBase}
           />
-        </label>
-        <label className="block">
+        </div>
+
+        {/* 오픈채팅 */}
+        <div className="rounded-2xl border border-slate-100 bg-slate-50/40 p-4">
           <div className="flex items-center gap-2 text-sm font-bold text-slate-700">
             <BrandIcon kind="kakao" /> 오픈채팅 URL
           </div>
           <input
-            value={content.links.kakaoUrl}
+            value={kakaoUrl}
             onChange={(e) =>
               updateContent({
                 ...content,
                 links: { ...content.links, kakaoUrl: e.target.value },
               })
             }
-            className="mt-2 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm outline-none focus:border-primary/60"
+            placeholder="https://open.kakao.com/o/..."
+            className={inputBase}
           />
-        </label>
+        </div>
       </div>
     </Reveal>
   );

--- a/src/pages/admin/sections/linksSave.ts
+++ b/src/pages/admin/sections/linksSave.ts
@@ -1,0 +1,23 @@
+import type { AdminContent } from '../../../utils/adminContent';
+import { snsAdminApi } from '../../../api/sns';
+
+export async function saveLinksToApi(content: AdminContent) {
+  const instagramUrl = (content.links.instagramUrl ?? '').trim();
+  const kakaoUrl = (content.links.kakaoUrl ?? '').trim();
+
+  const tasks: Promise<void>[] = [];
+  if (instagramUrl)
+    tasks.push(snsAdminApi.upsertInstagram({ url: instagramUrl }));
+  if (kakaoUrl) tasks.push(snsAdminApi.upsertKakao({ url: kakaoUrl }));
+
+  if (tasks.length === 0) {
+    return { updated: false, message: '반영할 링크가 없어요.' };
+  }
+
+  await Promise.all(tasks);
+
+  // 플로팅 즉시 갱신
+  window.dispatchEvent(new Event('sns-updated'));
+
+  return { updated: true, message: 'SNS 링크가 저장됐어요.' };
+}


### PR DESCRIPTION
#24 

# 작업 내용
- 관리자 페이지에서 인스타그램 / 카카오 오픈채팅 링크 관리 기능 구현
- SNS 링크 조회 및 수정 API 연동
- 저장 버튼을 통한 서버 반영
