### PR TITLE
fix: OAuth 로그인 토큰 전달 방식 수정

### DIFF
--- a/src/pages/site/LoginPage.tsx
+++ b/src/pages/site/LoginPage.tsx
@@ -25,7 +25,6 @@ export default function LoginPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
 
-  // ✅ 기본은 항상 user, 단 ?mode=admin이면 admin
   const initialMode: Mode = useMemo(() => {
     const q = searchParams.get('mode');
     if (q === 'admin') return 'admin';
@@ -71,11 +70,6 @@ export default function LoginPage() {
     );
   };
 
-  /**
-   * ✅ 소셜 로그인 팝업 열기
-   * - 새창에서 authorize URL 이동
-   * - 성공 시 /login/success 페이지에서 postMessage로 부모창에 토큰 전달
-   */
   const startSocialLogin = (provider: 'kakao' | 'naver') => {
     clearMessageIfNeeded();
 
@@ -87,7 +81,6 @@ export default function LoginPage() {
       return;
     }
 
-    // ✅ provider를 callback에서 알 수 있게 query로 추가
     const popupUrl = `${url}${
       url.includes('?') ? '&' : '?'
     }provider=${provider}`;
@@ -97,7 +90,6 @@ export default function LoginPage() {
     const left = Math.max(0, window.screenX + (window.outerWidth - width) / 2);
     const top = Math.max(0, window.screenY + (window.outerHeight - height) / 2);
 
-    console.log('popupUrl =', popupUrl);
 const popup = window.open(
   popupUrl,
   'social-login',
@@ -117,12 +109,6 @@ console.log('popup =', popup);
     popup.focus();
   };
 
-  /**
-   * ✅ 팝업에서 postMessage로 "로그인 성공"을 보내면 여기서 받음
-   * - 토큰 저장
-   * - 팝업 닫기
-   * - 메인으로 이동
-   */
   useEffect(() => {
     const onMessage = (event: MessageEvent) => {
       // 보안: 같은 origin만 허용(개발 중이면 localhost / 배포면 도메인에 맞게)

--- a/src/pages/site/OAuthCallbackPage.tsx
+++ b/src/pages/site/OAuthCallbackPage.tsx
@@ -45,20 +45,17 @@ export default function OAuthCallbackPage({ provider }: Props) {
                 return loginWithNaver(code, state);
               })();
 
-        // ✅ 팝업으로 열린 콜백이면: 부모창(LoginPage)으로 토큰 전달 → 팝업 닫기
         if (window.opener && !window.opener.closed) {
           const msg: SocialAuthMessage = {
             type: 'SOCIAL_AUTH_SUCCESS',
             accessToken: res.accessToken,
           };
 
-          // 우선 동작 안정성 위해 '*' 사용 (배포 시 프론트 도메인으로 좁히는 걸 추천)
           window.opener.postMessage(msg, '*');
           window.close();
           return;
         }
 
-        // ✅ 팝업이 아니라 현재 탭에서 열린 콜백이면: 직접 저장 후 이동
         localStorage.setItem(TOKEN_KEY, res.accessToken);
         navigate('/', { replace: true });
       } catch (e) {


### PR DESCRIPTION
## 변경 사항
- OAuth 소셜 로그인 플로우 수정
- 팝업 기반 로그인 흐름으로 통일
- OAuth 콜백 처리 로직 개선

## 상세 내용
### LoginPage
- 소셜 로그인 버튼 클릭 시 팝업으로 authorize URL 호출
- OAuth 콜백 페이지에서 postMessage로 accessToken 수신
- 토큰 수신 후 localStorage 저장 및 메인 페이지 이동

### OAuthCallbackPage
- popup / non-popup 접근 분기 처리
  - 팝업 접근 시: 부모창으로 토큰 전달 후 자동 close
  - 직접 접근 시: 토큰 저장 후 메인 페이지 redirect
- 에러 발생 시 메시지 처리 추가

## 환경변수 정리
프론트에서 아래 환경변수 사용
- VITE_API_BASE_URL
- VITE_KAKAO_AUTHORIZE_URL
- VITE_NAVER_AUTHORIZE_URL
- VITE_TOKEN_KEY

## 테스트
- 카카오 로그인 팝업 정상 동작 확인
- OAuth 콜백 후 토큰 localStorage 저장 확인
- 로그인 완료 후 메인 페이지 이동 확인