### PR TITLE
Fix: 카카오 로그인 팝업 종료 및 콜백 라우트 보완

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,12 +34,16 @@ export default function App() {
           <Route path="/mypage" element={<MyPage />} />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/admin/login" element={<LoginPage />} />
-          <Route path="/oauth/callback" element={<OAuthCallbackPage />} />
+          <Route path="/oauth/kakao/callback" element={<OAuthCallbackPage />} />
+          <Route path="/oauth/naver/callback" element={<OAuthCallbackPage />} />
         </Route>
         <Route element={<AdminLayout />}>
           <Route path="/admin" element={<AdminDashboardPage />} />
           <Route path="/admin/projects" element={<AdminProjectsListPage />} />
-          <Route path="/admin/projects/new" element={<AdminProjectEditorPage />} />
+          <Route
+            path="/admin/projects/new"
+            element={<AdminProjectEditorPage />}
+          />
           <Route
             path="/admin/projects/:projectId/edit"
             element={<AdminProjectEditorPage />}


### PR DESCRIPTION
#38 

## 요약
카카오 로그인 팝업이 닫히지 않는 문제 수정

## 변경 사항
- `/oauth/kakao/callback`, `/oauth/naver/callback` 라우트 추가
- 콜백 페이지에서 provider 경로 추론 및 팝업 닫기 보강
- 팝업 닫기 실패 시 `/login`으로 fallback 처리

## 테스트
- 배포 후 카카오 로그인 성공 시 팝업 자동 종료 확인
- 실패 시에도 팝업 닫힘/리다이렉트 확인

## 체크리스트
- [x] 라우트 매칭 오류 해결
- [x] 팝업 닫기 동작 보장
- [x] 기존 로그인 플로우 영향 없음

## 참고
> 아직 배포 환경에서 완전히 검증하지는 못했습니다. 배포 후 로그인 팝업 종료 동작을 최종 확인할 예정입니다.