### PR TITLE
fix: 메인 네비게이션 무료배포 탭 제거

### DIFF
--- a/src/components/HeaderDesktop.tsx
+++ b/src/components/HeaderDesktop.tsx
@@ -75,14 +75,6 @@ export default function HeaderDesktop() {
       </div>
 
       <Link
-        to="/resources"
-        onClick={() => setOpen(null)}
-        className="rounded-lg px-3 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-100 hover:text-primary"
-      >
-        FREE RESOURCES
-      </Link>
-
-      <Link
         to="/settlements"
         onClick={() => setOpen(null)}
         className="rounded-lg px-3 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-100 hover:text-primary"

--- a/src/components/HeaderMobile.tsx
+++ b/src/components/HeaderMobile.tsx
@@ -183,7 +183,6 @@ export default function HeaderMobile() {
             </div>
 
             {[
-              { label: 'FREE RESOURCES', href: '/resources' },
               { label: 'APPLY', href: '/forms' },
               { label: 'CONTACT', href: '/contact' },
               { label: 'PAYOUTS', href: '/settlements' },


### PR DESCRIPTION
## 요약
메인 페이지 네비게이션에서 사용하지 않는 FREE RESOURCES(무료배포) 탭을 제거했습니다.
---

## 작업내용
- 데스크톱 헤더에서 FREE RESOURCES 메뉴 삭제
- HeaderDesktop.tsx
- 모바일 헤더 메뉴 목록에서 FREE RESOURCES 항목 삭제
- HeaderMobile.tsx
- 기타 메뉴 동작 및 라우팅은 기존과 동일하게 유지했습니다.
