### PR TITLE
fix: 메인/프로젝트 카드 크기 조정 및 관리자 소개 탭 상단 저장 버튼 숨김

### DIFF
--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -7,18 +7,22 @@ import type { Project } from '../api/projects';
 type ProjectCardProps = {
   project: Project;
   showApplyAction?: boolean;
+  size?: 'default' | 'large' | 'main';
 };
 
 export default function ProjectCard({
   project,
   showApplyAction = true,
+  size = 'default',
 }: ProjectCardProps) {
   const canApply = project.status === 'OPEN';
   const deadlineText = project.endAt || '';
+  const isLarge = size === 'large';
+  const isMain = size === 'main';
 
   return (
     <div className="flex h-full flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white">
-      <div className="relative h-40 bg-slate-100">
+      <div className={`relative bg-slate-100 ${isMain ? 'h-56' : isLarge ? 'h-48' : 'h-40'}`}>
         {project.thumbnailUrl ? (
           <img
             src={project.thumbnailUrl}

--- a/src/pages/admin/AdminDashboardPage.tsx
+++ b/src/pages/admin/AdminDashboardPage.tsx
@@ -136,30 +136,32 @@ export default function AdminDashboardPage() {
             <p className="mt-2 text-sm text-slate-600">관리자 권한</p>
           </div>
 
-          <div className="flex flex-col items-end gap-2">
-            <button
-              type="button"
-              onClick={handleSave}
-              disabled={saving}
-              className={[
-                'rounded-xl bg-primary px-4 py-2 text-sm font-bold text-white transition',
-                saving ? 'opacity-60' : 'hover:opacity-95',
-              ].join(' ')}
-            >
-              {saving ? '저장 중...' : dirty ? '변경사항 저장' : '저장'}
-            </button>
+          {section !== 'about' && (
+            <div className="flex flex-col items-end gap-2">
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={saving}
+                className={[
+                  'rounded-xl bg-primary px-4 py-2 text-sm font-bold text-white transition',
+                  saving ? 'opacity-60' : 'hover:opacity-95',
+                ].join(' ')}
+              >
+                {saving ? '저장 중...' : dirty ? '변경사항 저장' : '저장'}
+              </button>
 
-            <div className="min-h-4.5">
-              {saveMsg && saveMsgTone === 'success' && (
-                <p className="text-xs font-semibold text-emerald-600">
-                  {saveMsg}
-                </p>
-              )}
-              {saveMsg && saveMsgTone === 'error' && (
-                <p className="text-xs font-semibold text-rose-600">{saveMsg}</p>
-              )}
+              <div className="min-h-4.5">
+                {saveMsg && saveMsgTone === 'success' && (
+                  <p className="text-xs font-semibold text-emerald-600">
+                    {saveMsg}
+                  </p>
+                )}
+                {saveMsg && saveMsgTone === 'error' && (
+                  <p className="text-xs font-semibold text-rose-600">{saveMsg}</p>
+                )}
+              </div>
             </div>
-          </div>
+          )}
         </div>
       </Reveal>
 

--- a/src/pages/site/MainPage.tsx
+++ b/src/pages/site/MainPage.tsx
@@ -124,7 +124,7 @@ export default function MainPage() {
     <div>
       <IntroduceMainView data={introMain} loading={introLoading} variant="public" linkToAbout />
 
-      <section className="mx-auto max-w-6xl px-4 py-14">
+      <section className="mx-auto max-w-7xl px-4 py-14">
         <Reveal>
           <div className="flex items-end justify-between gap-4">
             <div>
@@ -157,10 +157,10 @@ export default function MainPage() {
                   <div
                     key={project.id}
                     data-card
-                    className="shrink-0 snap-start w-[280px] max-w-[380px] sm:w-[320px] md:w-[360px] lg:w-[380px]"
+                    className="shrink-0 snap-start w-[290px] sm:w-[330px] md:w-[370px] lg:w-[calc((100%-2rem)/3)]"
                   >
                     <Reveal delayMs={index * 80}>
-                      <ProjectCard project={project} showApplyAction={false} />
+                      <ProjectCard project={project} showApplyAction={false} size="main" />
                     </Reveal>
                   </div>
                 ))}

--- a/src/pages/site/ProjectDetailPage.tsx
+++ b/src/pages/site/ProjectDetailPage.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { Calendar, Clock } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkBreaks from 'remark-breaks';
+import remarkGfm from 'remark-gfm';
 import Reveal from '../../components/Reveal';
 import StatusBadge from '../../components/StatusBadge';
 import { useToast } from '../../components/toast/useToast';
@@ -229,6 +232,66 @@ export default function ProjectDetailPage() {
             </div>
           </div>
         </div>
+      </Reveal>
+
+      <Reveal className="mt-8 rounded-3xl border border-slate-200 bg-white p-6">
+        <h2 className="font-heading text-xl text-slate-900">상세 설명</h2>
+        {project.description && project.description.trim().length > 0 ? (
+          <div className="mt-4 text-sm text-slate-700">
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm, remarkBreaks]}
+              components={{
+                h1: ({ ...props }) => (
+                  <h3 className="mt-5 text-lg font-heading text-slate-900 first:mt-0" {...props} />
+                ),
+                h2: ({ ...props }) => (
+                  <h4 className="mt-4 text-base font-heading text-slate-900 first:mt-0" {...props} />
+                ),
+                p: ({ ...props }) => (
+                  <p className="mt-3 whitespace-normal break-words leading-relaxed first:mt-0" {...props} />
+                ),
+                ul: ({ ...props }) => (
+                  <ul className="mt-3 list-disc space-y-1 pl-5 first:mt-0" {...props} />
+                ),
+                ol: ({ ...props }) => (
+                  <ol className="mt-3 list-decimal space-y-1 pl-5 first:mt-0" {...props} />
+                ),
+                a: ({ ...props }) => (
+                  <a
+                    className="text-primary underline decoration-slate-300 underline-offset-4 break-words"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    {...props}
+                  />
+                ),
+                code: ({ className, ...props }) => {
+                  const isBlock = Boolean(className);
+                  if (isBlock) {
+                    return <code className="block whitespace-pre-wrap break-words" {...props} />;
+                  }
+                  return (
+                    <code
+                      className="rounded bg-slate-100 px-1.5 py-0.5 text-xs font-mono text-slate-700"
+                      {...props}
+                    />
+                  );
+                },
+                pre: ({ ...props }) => (
+                  <pre
+                    className="mt-4 overflow-x-auto rounded-2xl border border-slate-200 bg-slate-50 p-4 text-xs text-slate-700"
+                    {...props}
+                  />
+                ),
+              }}
+            >
+              {project.description}
+            </ReactMarkdown>
+          </div>
+        ) : (
+          <p className="mt-4 text-sm font-semibold text-slate-400">
+            등록된 상세 설명이 없어요
+          </p>
+        )}
       </Reveal>
 
       <div className="mt-8">

--- a/src/pages/site/ProjectsPage.tsx
+++ b/src/pages/site/ProjectsPage.tsx
@@ -14,6 +14,7 @@ const TABS: { label: string; value: TabValue }[] = [
   { label: '준비중', value: 'PREPARING' },
   { label: '마감', value: 'CLOSED' },
 ];
+const PROJECT_CARD_WRAP_CLASS = 'mx-auto w-full max-w-[460px]';
 
 function isProjectStatus(v: string): v is ProjectStatus {
   return v === 'OPEN' || v === 'PREPARING' || v === 'CLOSED';
@@ -83,7 +84,7 @@ export default function ProjectsPage() {
   }, [filtered]);
 
   return (
-    <div className="mx-auto max-w-6xl px-4 py-12">
+    <div className="mx-auto max-w-7xl px-4 py-12">
       <Reveal>
         <h1 className="font-heading text-3xl text-primary">프로젝트</h1>
         <p className="mt-2 text-slate-600">
@@ -116,10 +117,12 @@ export default function ProjectsPage() {
       </Reveal>
 
       {pinnedProjects.length > 0 && (
-        <div className="mt-8 grid grid-cols-1 gap-5 md:grid-cols-3">
+        <div className="mt-8 grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
           {pinnedProjects.map((p, i) => (
             <Reveal key={p.id} delayMs={i * 40}>
-              <ProjectCard project={p} />
+              <div className={PROJECT_CARD_WRAP_CLASS}>
+                <ProjectCard project={p} size="large" showApplyAction={false} />
+              </div>
             </Reveal>
           ))}
         </div>
@@ -131,10 +134,12 @@ export default function ProjectsPage() {
             {year}
           </div>
           <div className="mt-4 border-t border-slate-200" />
-          <div className="mt-8 grid grid-cols-1 gap-5 md:grid-cols-3">
+          <div className="mt-8 grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
             {items.map((p, i) => (
               <Reveal key={p.id} delayMs={(sectionIndex + i) * 40}>
-                <ProjectCard project={p} />
+                <div className={PROJECT_CARD_WRAP_CLASS}>
+                  <ProjectCard project={p} size="large" showApplyAction={false} />
+                </div>
               </Reveal>
             ))}
           </div>


### PR DESCRIPTION
## 요약

데모 테스트를 바탕으로 사용자 ui 및 관리자 페이지 ui 를 수정하였습니다.
---

## 작업내용

- 메인페이지 프로젝트 카드 크기/비율 조정 (이미지 영역 확대 포함)
- /projects 카드 크기 최종 조정 및 카드 크기 일관성 맞춤
- /projects 카드의 신청하기 버튼 제거 (상세 보기만 노출)
- 프로젝트 상세 페이지에 상세 설명 노출 추가
- 관리자 소개 탭에서 상단 저장 버튼 숨김 (섹션 저장만 사용)