### PR TITLE
feat: 상품 판매유형별 수량 입력 필드 분기

### DIFF
--- a/src/api/adminItems.ts
+++ b/src/api/adminItems.ts
@@ -28,6 +28,7 @@ export type AdminItemResponse = {
   thumbnailUrl?: string | null;
   targetQty?: number | null;
   fundedQty?: number | null;
+  stockQty?: number | null;
   journalFileKey?: string | null;
   achievementRate?: number | null;
   remainingQty?: number | null;
@@ -48,6 +49,7 @@ export type AdminItemUpsertRequest = {
   thumbnailKey?: string;
   targetQty?: number | null;
   fundedQty?: number | null;
+  stockQty?: number | null;
 };
 
 export type PresignPutRequest = {


### PR DESCRIPTION
## 요약
관리자 상품 관리 폼에서 판매유형에 따라 수량 입력 필드를 분기하고, 입력 변경 시 저장 버튼 활성화가 즉시 반영되도록 수정했습니다.

---

## 작업내용

- 판매유형 UI 개선
  - 판매유형 선택을 버튼형으로 변경해 클릭 영역/가독성 개선
- 판매유형별 수량 필드 분기
  - `일반(NORMAL)`: `재고(stockQty)` 입력 노출
  - `공구(GROUPBUY)`: `펀딩 수량(fundedQty)` + `목표 수량(targetQty)` 입력 노출
- 저장 payload 정리
  - `NORMAL` 저장 시 `stockQty` 사용, `fundedQty/targetQty`는 `null`
  - `GROUPBUY` 저장 시 `fundedQty/targetQty` 사용, `stockQty`는 `null`
- 저장 버튼 활성화 이슈 해결
  - 숫자 입력값(`가격/재고/펀딩수량`)을 `onBlur`뿐 아니라 `onChange`에서도 상태 반영하여 변경 감지 즉시 활성화되도록 수정