### PR TITLE
Feat: 사용자 지원서 작성/수정/결과 화면 및 API 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes, useLocation } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import SiteLayout from './components/SiteLayout';
 import AdminLayout from './components/AdminLayout';
 import MainPage from './pages/site/MainPage';
@@ -11,31 +11,25 @@ import ProjectDetailPage from './pages/site/ProjectDetailPage';
 import ProjectItemDetailPage from './pages/site/ProjectItemDetailPage';
 import ResourcesPage from './pages/site/ResourcesPage';
 import SettlementsPage from './pages/site/SettlementsPage';
-import CartPage from './pages/site/CartPage';
-import OrderPage from './pages/site/OrderPage';
-import OrderCompletePage from './pages/site/OrderCompletePage';
-import OrderLookupPage from './pages/site/OrderLookupPage';
-import OrderViewPage from './pages/site/OrderViewPage';
 import LoginPage from './pages/site/LoginPage';
 import OAuthCallbackPage from './pages/site/OAuthCallbackPage';
 import NoticesPage from './pages/site/NoticesPage';
 import NoticeDetailPage from './pages/site/NoticeDetailPage';
+import ApplyPage from './pages/site/ApplyPage';
+import ApplicationEditPage from './pages/site/ApplicationEditPage';
+import ApplicationResultPage from './pages/site/ApplicationResultPage';
 import AdminDashboardPage from './pages/admin/AdminDashboardPage';
 import AdminProjectsListPage from './pages/admin/AdminProjectsListPage';
 import AdminProjectEditorPage from './pages/admin/AdminProjectEditorPage';
 import AdminProjectItemsListPage from './pages/admin/AdminProjectItemsListPage';
 import AdminProjectItemCreatePage from './pages/admin/AdminProjectItemCreatePage';
 import AdminItemDetailPage from './pages/admin/AdminItemDetailPage';
-import AdminOrdersPage from './pages/admin/AdminOrdersPage';
 import AdminNoticesListPage from './pages/admin/AdminNoticesListPage';
 import AdminNoticeEditorPage from './pages/admin/AdminNoticeEditorPage';
 import AdminNoticeDetailPage from './pages/admin/AdminNoticeDetailPage';
 import FloatingSns from './components/FloatingSns';
 
 export default function App() {
-  const location = useLocation();
-  const hideFloatingSns = location.pathname.startsWith('/orders/');
-
   return (
     <>
       <Routes>
@@ -48,21 +42,20 @@ export default function App() {
             element={<ProjectItemDetailPage />}
           />
           <Route path="/resources" element={<ResourcesPage />} />
-          <Route path="/cart" element={<CartPage />} />
-          <Route path="/order" element={<OrderPage />} />
-          <Route path="/order/complete" element={<OrderCompletePage />} />
           <Route path="/settlements" element={<SettlementsPage />} />
           <Route path="/about" element={<AboutPage />} />
           <Route path="/forms" element={<FormPage />} />
+          <Route path="/apply" element={<ApplyPage />} />
+          <Route path="/apply/edit" element={<ApplicationEditPage />} />
+          <Route path="/apply/result" element={<ApplicationResultPage />} />
+          <Route path="/notices" element={<NoticesPage />} />
+          <Route path="/notices/:noticeId" element={<NoticeDetailPage />} />
           <Route path="/contact" element={<ContactPage />} />
           <Route path="/mypage" element={<MyPage />} />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/oauth/kakao/callback" element={<OAuthCallbackPage />} />
           <Route path="/oauth/naver/callback" element={<OAuthCallbackPage />} />
-          <Route path="/notices" element={<NoticesPage />} />
-          <Route path="/notices/:noticeId" element={<NoticeDetailPage />} />
         </Route>
-
         <Route element={<AdminLayout />}>
           <Route path="/admin" element={<AdminDashboardPage />} />
           <Route path="/admin/projects" element={<AdminProjectsListPage />} />
@@ -86,7 +79,6 @@ export default function App() {
             path="/admin/items/:itemId"
             element={<AdminItemDetailPage />}
           />
-          <Route path="/admin/orders" element={<AdminOrdersPage />} />
           <Route path="/admin/notices" element={<AdminNoticesListPage />} />
           <Route
             path="/admin/notices/new"
@@ -101,11 +93,9 @@ export default function App() {
             element={<AdminNoticeEditorPage />}
           />
         </Route>
-        <Route path="/orders/lookup" element={<OrderLookupPage />} />
-        <Route path="/orders/view" element={<OrderViewPage />} />
       </Routes>
 
-      {!hideFloatingSns && <FloatingSns />}
+      <FloatingSns />
     </>
   );
 }

--- a/src/api/applications.ts
+++ b/src/api/applications.ts
@@ -1,0 +1,151 @@
+import { api, withApiBase } from './client';
+import { unwrapApiResult } from './types';
+import type { ApiResult } from './types';
+
+export type ApplicationNotice = {
+  noticeId: number | string;
+  sectionType?: string | null;
+  departmentType?: string | null;
+  title?: string | null;
+  content?: string | null;
+};
+
+export type ApplicationQuestion = {
+  formQuestionId: number;
+  questionOrder?: number | null;
+  content?: string | null;
+  description?: string | null;
+  answerType?: string | null;
+  required?: boolean | null;
+  sectionType?: string | null;
+  departmentType?: string | null;
+  selectOptions?: string | null;
+};
+
+export type ApplicationFormResponse = {
+  formId: number;
+  title?: string | null;
+  notices?: ApplicationNotice[] | null;
+  questions?: ApplicationQuestion[] | null;
+};
+
+export type ApplicationAnswer = {
+  formQuestionId: number;
+  value: string | null;
+};
+
+export type ApplicationCreateRequest = {
+  studentId: string;
+  password: string;
+  firstDepartment: string;
+  secondDepartment: string;
+  answers: ApplicationAnswer[];
+};
+
+export type ApplicationUpdateRequest = ApplicationCreateRequest;
+
+export type ApplicationReadRequest = {
+  studentId: string;
+  password: string;
+};
+
+export type ApplicationReadResponse = {
+  editable?: boolean | null;
+  applicationId?: number | string | null;
+  studentId?: string | null;
+  firstDepartment?: string | null;
+  secondDepartment?: string | null;
+  createdAt?: string | number[] | null;
+  updatedAt?: string | number[] | null;
+  commonNotice?: { title?: string | null; content?: string | null } | null;
+  firstDepartmentNotice?: {
+    title?: string | null;
+    content?: string | null;
+  } | null;
+  secondDepartmentNotice?: {
+    title?: string | null;
+    content?: string | null;
+  } | null;
+  commonAnswers?: ApplicationAnswer[] | null;
+  firstDepartmentAnswers?: ApplicationAnswer[] | null;
+  secondDepartmentAnswers?: ApplicationAnswer[] | null;
+  questions?: ApplicationQuestion[] | null;
+  notices?: ApplicationNotice[] | null;
+};
+
+export type ApplicationResultRequest = {
+  studentId: string;
+  password: string;
+};
+
+export type ApplicationResultResponse = {
+  resultStatus?: string | null;
+  message?: string | null;
+};
+
+export type PresignFileRequest = Array<{
+  fileName: string;
+  contentType: string;
+}>;
+
+export type PresignFileItem = {
+  fileName: string;
+  key: string;
+  uploadUrl: string;
+  expiresInSeconds: number;
+};
+
+export type PresignFileResponse = {
+  items: PresignFileItem[];
+};
+
+export const applicationsApi = {
+  getForm() {
+    return api<ApiResult<ApplicationFormResponse> | ApplicationFormResponse>(
+      withApiBase('/application/form'),
+    ).then((res) => unwrapApiResult(res));
+  },
+
+  create(body: ApplicationCreateRequest) {
+    return api<ApiResult<void> | void>(withApiBase('/application'), {
+      method: 'POST',
+      body,
+    }).then((res) => unwrapApiResult(res));
+  },
+
+  update(body: ApplicationUpdateRequest) {
+    return api<ApiResult<void> | void>(withApiBase('/application'), {
+      method: 'PUT',
+      body,
+    }).then((res) => unwrapApiResult(res));
+  },
+
+  read(body: ApplicationReadRequest) {
+    return api<ApiResult<ApplicationReadResponse> | ApplicationReadResponse>(
+      withApiBase('/application/read'),
+      {
+        method: 'POST',
+        body,
+      },
+    ).then((res) => unwrapApiResult(res));
+  },
+
+  getResult(body: ApplicationResultRequest) {
+    return api<
+      ApiResult<ApplicationResultResponse> | ApplicationResultResponse
+    >(withApiBase('/result'), {
+      method: 'POST',
+      body,
+    }).then((res) => unwrapApiResult(res));
+  },
+
+  presignFiles(body: PresignFileRequest) {
+    return api<ApiResult<PresignFileResponse> | PresignFileResponse>(
+      withApiBase('/forms/files'),
+      {
+        method: 'POST',
+        body,
+      },
+    ).then((res) => unwrapApiResult(res));
+  },
+};

--- a/src/components/HeaderDesktop.tsx
+++ b/src/components/HeaderDesktop.tsx
@@ -2,13 +2,12 @@ import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 
-type MenuKey = 'projects' | 'order' | null;
+type MenuKey = 'projects' | null;
 
 export default function HeaderDesktop() {
   const navigate = useNavigate();
   const [open, setOpen] = useState<MenuKey>(null);
   const isProjectsOpen = open === 'projects';
-  const isOrderOpen = open === 'order';
   const { isLoggedIn } = useAuth();
 
   return (
@@ -100,7 +99,7 @@ export default function HeaderDesktop() {
       </Link>
 
       <Link
-        to="/forms"
+        to="/apply"
         onClick={() => setOpen(null)}
         className="rounded-lg px-3 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-100 hover:text-primary"
       >
@@ -114,58 +113,6 @@ export default function HeaderDesktop() {
       >
         CONTACT
       </Link>
-
-      <div className="relative">
-        <button
-          type="button"
-          onClick={() => setOpen(isOrderOpen ? null : 'order')}
-          className="rounded-lg px-3 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-100 hover:text-primary"
-          aria-expanded={isOrderOpen}
-          aria-haspopup="menu"
-        >
-          ORDER <span className="ml-1 text-slate-400">▾</span>
-        </button>
-
-        {isOrderOpen && (
-          <button
-            type="button"
-            aria-label="close dropdown"
-            className="fixed inset-0 z-40 cursor-default"
-            onClick={() => setOpen(null)}
-          />
-        )}
-
-        <div
-          className={[
-            'absolute right-0 z-50 mt-2 w-52 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-lg',
-            'transition-all duration-200 ease-out',
-            isOrderOpen
-              ? 'pointer-events-auto translate-y-0 opacity-100'
-              : 'pointer-events-none -translate-y-1 opacity-0',
-          ].join(' ')}
-          role="menu"
-        >
-          <div className="py-2">
-            {[
-              { label: 'CART', href: '/cart' },
-              { label: 'ORDER LOOKUP', href: '/orders/lookup' },
-            ].map((x) => (
-              <button
-                key={x.href}
-                type="button"
-                onClick={() => {
-                  setOpen(null);
-                  navigate(x.href);
-                }}
-                className="w-full px-4 py-2 text-left text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100 hover:text-primary"
-                role="menuitem"
-              >
-                {x.label}
-              </button>
-            ))}
-          </div>
-        </div>
-      </div>
 
       <button
         type="button"

--- a/src/components/HeaderMobile.tsx
+++ b/src/components/HeaderMobile.tsx
@@ -240,7 +240,8 @@ export default function HeaderMobile() {
             </div>
 
             {[
-              { label: 'APPLY', href: '/forms' },
+              { label: 'FREE RESOURCES', href: '/resources' },
+              { label: 'APPLY', href: '/apply' },
               { label: 'CONTACT', href: '/contact' },
               { label: 'PAYOUTS', href: '/settlements' },
             ].map((item) => (

--- a/src/pages/site/ApplicationEditPage.tsx
+++ b/src/pages/site/ApplicationEditPage.tsx
@@ -1,0 +1,483 @@
+import { useCallback, useMemo, useState } from 'react';
+import Reveal from '../../components/Reveal';
+import {
+  applicationsApi,
+  type ApplicationFormResponse,
+  type ApplicationQuestion,
+  type ApplicationReadResponse,
+} from '../../api/applications';
+import { uploadToPresignedUrl } from '../../api/adminProjects';
+
+type AnswerValue = string | string[] | null;
+type FileState = {
+  key?: string | null;
+  uploading?: boolean;
+  error?: string | null;
+};
+
+function parseOptions(raw?: string | null): string[] {
+  if (!raw) return [];
+  const trimmed = raw.trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) return parsed.map((x) => String(x));
+    } catch {
+      // fallthrough
+    }
+  }
+  return trimmed
+    .split(/\r?\n|,/g)
+    .map((x) => x.trim())
+    .filter(Boolean);
+}
+
+function normalizeAnswerValue(value: AnswerValue) {
+  if (value == null) return null;
+  if (Array.isArray(value)) {
+    const filtered = value.map((v) => v.trim()).filter(Boolean);
+    return filtered.length ? filtered.join(',') : null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : null;
+}
+
+function getAnswerType(raw?: string | null) {
+  return (raw ?? '').toUpperCase();
+}
+
+function collectAnswers(data?: ApplicationReadResponse | null) {
+  const list: Array<{ formQuestionId: number; value: string | null }> = [];
+  const push = (
+    arr?: Array<{ formQuestionId: number; value: string | null }> | null,
+  ) => {
+    if (!arr) return;
+    arr.forEach((a) =>
+      list.push({ formQuestionId: a.formQuestionId, value: a.value ?? null }),
+    );
+  };
+  push(data?.commonAnswers);
+  push(data?.firstDepartmentAnswers);
+  push(data?.secondDepartmentAnswers);
+  return list;
+}
+
+export default function ApplicationEditPage() {
+  const [form, setForm] = useState<ApplicationFormResponse | null>(null);
+  const [readData, setReadData] = useState<ApplicationReadResponse | null>(
+    null,
+  );
+  const [loading, setLoading] = useState(true);
+  const [submitLoading, setSubmitLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const [studentId, setStudentId] = useState('');
+  const [password, setPassword] = useState('');
+  const [firstDepartment, setFirstDepartment] = useState('');
+  const [secondDepartment, setSecondDepartment] = useState('');
+
+  const [answers, setAnswers] = useState<Record<number, AnswerValue>>({});
+  const [files, setFiles] = useState<Record<number, FileState>>({});
+  const [loaded, setLoaded] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await applicationsApi.read({
+        studentId: studentId.trim(),
+        password: password.trim(),
+      });
+      setReadData(res ?? null);
+
+      const formRes = await applicationsApi.getForm();
+      setForm(formRes ?? null);
+
+      const existing = collectAnswers(res);
+      const next: Record<number, AnswerValue> = {};
+      existing.forEach((a) => {
+        if (a.value == null) return;
+        next[a.formQuestionId] = a.value;
+      });
+      setAnswers(next);
+
+      setFirstDepartment(res?.firstDepartment ?? '');
+      setSecondDepartment(res?.secondDepartment ?? '');
+      setLoaded(true);
+    } catch {
+      setError('지원서를 찾을 수 없어요.');
+    } finally {
+      setLoading(false);
+    }
+  }, [password, studentId]);
+
+  const questions = useMemo(() => {
+    return (form?.questions ?? []).slice().sort((a, b) => {
+      const ao = a.questionOrder ?? 0;
+      const bo = b.questionOrder ?? 0;
+      return ao - bo;
+    });
+  }, [form?.questions]);
+
+  const handleAnswerChange = (id: number, value: AnswerValue) => {
+    setAnswers((prev) => ({ ...prev, [id]: value }));
+  };
+
+  const handleFileUpload = async (q: ApplicationQuestion, file: File) => {
+    const qid = q.formQuestionId;
+    setFiles((prev) => ({
+      ...prev,
+      [qid]: { ...prev[qid], uploading: true, error: null },
+    }));
+
+    try {
+      const res = await applicationsApi.presignFiles([
+        {
+          fileName: file.name,
+          contentType: file.type || 'application/octet-stream',
+        },
+      ]);
+      const target = res.items?.[0];
+      if (!target) throw new Error('업로드 URL이 없어요.');
+      await uploadToPresignedUrl(
+        target.uploadUrl,
+        file,
+        file.type || 'application/octet-stream',
+      );
+
+      setFiles((prev) => ({
+        ...prev,
+        [qid]: { key: target.key, uploading: false, error: null },
+      }));
+      handleAnswerChange(qid, target.key);
+    } catch {
+      setFiles((prev) => ({
+        ...prev,
+        [qid]: {
+          ...prev[qid],
+          uploading: false,
+          error: '파일 업로드에 실패했어요.',
+        },
+      }));
+    }
+  };
+
+  const handleSubmit = async () => {
+    setValidationError(null);
+
+    if (!studentId.trim() || !password.trim()) {
+      setValidationError('학번과 비밀번호를 입력해주세요.');
+      return;
+    }
+    if (!firstDepartment.trim() || !secondDepartment.trim()) {
+      setValidationError('1지망/2지망을 모두 입력해주세요.');
+      return;
+    }
+    if (firstDepartment.trim() === secondDepartment.trim()) {
+      setValidationError('1지망과 2지망은 서로 달라야 해요.');
+      return;
+    }
+
+    for (const q of questions) {
+      const val = normalizeAnswerValue(answers[q.formQuestionId] ?? null);
+      if (q.required && !val) {
+        setValidationError(
+          `필수 질문을 입력해주세요: ${q.content ?? ''}`.trim(),
+        );
+        return;
+      }
+      if (getAnswerType(q.answerType).includes('FILE')) {
+        const f = files[q.formQuestionId];
+        if (q.required && (!f || !f.key)) {
+          setValidationError(
+            `필수 파일을 업로드해주세요: ${q.content ?? ''}`.trim(),
+          );
+          return;
+        }
+      }
+    }
+
+    const payloadAnswers = questions.map((q) => {
+      const value = normalizeAnswerValue(answers[q.formQuestionId] ?? null);
+      return { formQuestionId: q.formQuestionId, value: value ?? null };
+    });
+
+    setSubmitLoading(true);
+    try {
+      await applicationsApi.update({
+        studentId: studentId.trim(),
+        password: password.trim(),
+        firstDepartment: firstDepartment.trim(),
+        secondDepartment: secondDepartment.trim(),
+        answers: payloadAnswers,
+      });
+      alert('지원서가 수정되었습니다.');
+    } catch {
+      alert('지원서 수정에 실패했어요. 잠시 후 다시 시도해 주세요.');
+    } finally {
+      setSubmitLoading(false);
+    }
+  };
+
+  if (!loaded) {
+    return (
+      <div className="mx-auto max-w-6xl px-4 py-12">
+        <Reveal>
+          <h1 className="font-heading text-3xl text-primary">
+            지원서 조회/수정
+          </h1>
+          <p className="mt-2 text-sm text-slate-600">
+            학번과 비밀번호로 조회하세요.
+          </p>
+        </Reveal>
+
+        {error && (
+          <p className="mt-4 text-sm font-semibold text-rose-600">{error}</p>
+        )}
+
+        <Reveal
+          delayMs={120}
+          className="mt-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+        >
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label className="text-sm font-bold text-slate-700">학번</label>
+              <input
+                value={studentId}
+                onChange={(e) => setStudentId(e.target.value)}
+                className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none focus:border-primary/60 focus:ring-4 focus:ring-primary/10"
+              />
+            </div>
+            <div>
+              <label className="text-sm font-bold text-slate-700">
+                비밀번호
+              </label>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none focus:border-primary/60 focus:ring-4 focus:ring-primary/10"
+              />
+            </div>
+          </div>
+
+          <div className="mt-6 flex justify-end">
+            <button
+              type="button"
+              onClick={load}
+              className="rounded-xl bg-primary px-5 py-2.5 text-sm font-bold text-white shadow-lg transition hover:opacity-95"
+            >
+              조회하기
+            </button>
+          </div>
+        </Reveal>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-6xl px-4 py-12 text-sm text-slate-500">
+        불러오는 중...
+      </div>
+    );
+  }
+
+  if (readData?.editable === false) {
+    return (
+      <div className="mx-auto max-w-6xl px-4 py-12">
+        <h1 className="font-heading text-2xl text-slate-900">
+          지원서 수정 불가
+        </h1>
+        <p className="mt-3 text-sm text-slate-600">
+          모집 기간이 종료되어 수정할 수 없어요.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-12">
+      <Reveal>
+        <h1 className="font-heading text-3xl text-primary">지원서 수정</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          기존 지원서를 수정할 수 있어요.
+        </p>
+      </Reveal>
+
+      {validationError && (
+        <div className="mt-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-600">
+          {validationError}
+        </div>
+      )}
+
+      <Reveal
+        delayMs={120}
+        className="mt-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+      >
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <label className="text-sm font-bold text-slate-700">학번</label>
+            <input
+              value={studentId}
+              onChange={(e) => setStudentId(e.target.value)}
+              className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none focus:border-primary/60 focus:ring-4 focus:ring-primary/10"
+            />
+          </div>
+          <div>
+            <label className="text-sm font-bold text-slate-700">비밀번호</label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none focus:border-primary/60 focus:ring-4 focus:ring-primary/10"
+            />
+          </div>
+          <div>
+            <label className="text-sm font-bold text-slate-700">1지망</label>
+            <input
+              value={firstDepartment}
+              onChange={(e) => setFirstDepartment(e.target.value)}
+              className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none focus:border-primary/60 focus:ring-4 focus:ring-primary/10"
+            />
+          </div>
+          <div>
+            <label className="text-sm font-bold text-slate-700">2지망</label>
+            <input
+              value={secondDepartment}
+              onChange={(e) => setSecondDepartment(e.target.value)}
+              className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none focus:border-primary/60 focus:ring-4 focus:ring-primary/10"
+            />
+          </div>
+        </div>
+      </Reveal>
+
+      <Reveal
+        delayMs={180}
+        className="mt-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+      >
+        <h2 className="text-base font-bold text-slate-900">질문</h2>
+
+        <div className="mt-4 space-y-5">
+          {questions.map((q) => {
+            const type = getAnswerType(q.answerType);
+            const value = answers[q.formQuestionId] ?? '';
+            const options = parseOptions(q.selectOptions);
+
+            return (
+              <div key={q.formQuestionId} className="space-y-2">
+                <label className="text-sm font-bold text-slate-700">
+                  {q.content}
+                  {q.required && <span className="ml-1 text-rose-500">*</span>}
+                </label>
+                {q.description && (
+                  <p className="text-xs text-slate-400">{q.description}</p>
+                )}
+
+                {type.includes('FILE') ? (
+                  <div className="flex flex-col gap-2">
+                    <input
+                      type="file"
+                      onChange={(e) => {
+                        const file = e.target.files?.[0];
+                        if (file) void handleFileUpload(q, file);
+                      }}
+                      className="text-sm"
+                    />
+                    {files[q.formQuestionId]?.uploading && (
+                      <span className="text-xs text-slate-500">
+                        업로드 중...
+                      </span>
+                    )}
+                    {files[q.formQuestionId]?.key && (
+                      <span className="text-xs text-emerald-600">
+                        업로드 완료
+                      </span>
+                    )}
+                    {files[q.formQuestionId]?.error && (
+                      <span className="text-xs text-rose-600">
+                        {files[q.formQuestionId]?.error}
+                      </span>
+                    )}
+                  </div>
+                ) : type.includes('TEXTAREA') ? (
+                  <textarea
+                    value={String(value ?? '')}
+                    onChange={(e) =>
+                      handleAnswerChange(q.formQuestionId, e.target.value)
+                    }
+                    className="min-h-[120px] w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none focus:border-primary/60 focus:ring-4 focus:ring-primary/10"
+                  />
+                ) : type.includes('SELECT') || type.includes('RADIO') ? (
+                  <select
+                    value={String(value ?? '')}
+                    onChange={(e) =>
+                      handleAnswerChange(q.formQuestionId, e.target.value)
+                    }
+                    className="w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none focus:border-primary/60 focus:ring-4 focus:ring-primary/10"
+                  >
+                    <option value="">선택</option>
+                    {options.map((opt) => (
+                      <option key={opt} value={opt}>
+                        {opt}
+                      </option>
+                    ))}
+                  </select>
+                ) : type.includes('CHECK') || type.includes('MULTI') ? (
+                  <div className="flex flex-wrap gap-2">
+                    {options.map((opt) => {
+                      const arr = Array.isArray(value) ? value : [];
+                      const checked = arr.includes(opt);
+                      return (
+                        <label
+                          key={opt}
+                          className="flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-700"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={(e) => {
+                              const next = new Set(arr);
+                              if (e.target.checked) next.add(opt);
+                              else next.delete(opt);
+                              handleAnswerChange(
+                                q.formQuestionId,
+                                Array.from(next),
+                              );
+                            }}
+                          />
+                          {opt}
+                        </label>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <input
+                    value={String(value ?? '')}
+                    onChange={(e) =>
+                      handleAnswerChange(q.formQuestionId, e.target.value)
+                    }
+                    className="w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none focus:border-primary/60 focus:ring-4 focus:ring-primary/10"
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="mt-6 flex justify-end">
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitLoading}
+            className="rounded-xl bg-primary px-5 py-2.5 text-sm font-bold text-white shadow-lg transition hover:opacity-95 disabled:opacity-60"
+          >
+            {submitLoading ? '저장 중...' : '지원서 수정'}
+          </button>
+        </div>
+      </Reveal>
+    </div>
+  );
+}

--- a/src/pages/site/ApplicationResultPage.tsx
+++ b/src/pages/site/ApplicationResultPage.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import Reveal from '../../components/Reveal';
+import { applicationsApi } from '../../api/applications';
+
+function resultLabel(status?: string | null) {
+  if (!status) return '결과 없음';
+  const s = status.toUpperCase();
+  if (s.includes('PASS')) return '합격';
+  if (s.includes('FAIL')) return '불합격';
+  if (s.includes('NOT_PUBLISHED')) return '결과 미발표';
+  return status;
+}
+
+export default function ApplicationResultPage() {
+  const [studentId, setStudentId] = useState('');
+  const [password, setPassword] = useState('');
+  const [result, setResult] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleCheck = async () => {
+    setResult(null);
+    setMessage(null);
+
+    if (!studentId.trim() || !password.trim()) {
+      setMessage('학번과 비밀번호를 입력해주세요.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const res = await applicationsApi.getResult({
+        studentId: studentId.trim(),
+        password: password.trim(),
+      });
+      setResult(resultLabel(res?.resultStatus));
+      if (res?.message) setMessage(res.message);
+    } catch {
+      setMessage('결과를 찾을 수 없어요.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-12">
+      <Reveal>
+        <h1 className="font-heading text-3xl text-primary">지원 결과 조회</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          학번과 비밀번호로 결과를 확인하세요.
+        </p>
+      </Reveal>
+
+      <Reveal
+        delayMs={120}
+        className="mt-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+      >
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <label className="text-sm font-bold text-slate-700">학번</label>
+            <input
+              value={studentId}
+              onChange={(e) => setStudentId(e.target.value)}
+              className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none focus:border-primary/60 focus:ring-4 focus:ring-primary/10"
+            />
+          </div>
+          <div>
+            <label className="text-sm font-bold text-slate-700">비밀번호</label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none focus:border-primary/60 focus:ring-4 focus:ring-primary/10"
+            />
+          </div>
+        </div>
+
+        <div className="mt-6 flex justify-end">
+          <button
+            type="button"
+            onClick={handleCheck}
+            disabled={loading}
+            className="rounded-xl bg-primary px-5 py-2.5 text-sm font-bold text-white shadow-lg transition hover:opacity-95 disabled:opacity-60"
+          >
+            {loading ? '조회 중...' : '결과 조회'}
+          </button>
+        </div>
+      </Reveal>
+
+      {(result || message) && (
+        <Reveal
+          delayMs={180}
+          className="mt-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+        >
+          <p className="text-lg font-bold text-slate-900">
+            {result ?? '결과 없음'}
+          </p>
+          {message && <p className="mt-2 text-sm text-slate-600">{message}</p>}
+        </Reveal>
+      )}
+    </div>
+  );
+}

--- a/src/pages/site/ApplyPage.tsx
+++ b/src/pages/site/ApplyPage.tsx
@@ -1,0 +1,424 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Reveal from '../../components/Reveal';
+import {
+  applicationsApi,
+  type ApplicationFormResponse,
+  type ApplicationQuestion,
+} from '../../api/applications';
+import { uploadToPresignedUrl } from '../../api/adminProjects';
+
+type AnswerValue = string | string[] | null;
+
+type FileState = {
+  key?: string | null;
+  uploading?: boolean;
+  error?: string | null;
+};
+
+function parseOptions(raw?: string | null): string[] {
+  if (!raw) return [];
+  const trimmed = raw.trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) return parsed.map((x) => String(x));
+    } catch {
+      // fallthrough
+    }
+  }
+  return trimmed
+    .split(/\r?\n|,/g)
+    .map((x) => x.trim())
+    .filter(Boolean);
+}
+
+function normalizeAnswerValue(value: AnswerValue) {
+  if (value == null) return null;
+  if (Array.isArray(value)) {
+    const filtered = value.map((v) => v.trim()).filter(Boolean);
+    return filtered.length ? filtered.join(',') : null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : null;
+}
+
+function getAnswerType(raw?: string | null) {
+  return (raw ?? '').toUpperCase();
+}
+
+export default function ApplyPage() {
+  const [form, setForm] = useState<ApplicationFormResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [submitLoading, setSubmitLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const [studentId, setStudentId] = useState('');
+  const [password, setPassword] = useState('');
+  const [firstDepartment, setFirstDepartment] = useState('');
+  const [secondDepartment, setSecondDepartment] = useState('');
+
+  const [answers, setAnswers] = useState<Record<number, AnswerValue>>({});
+  const [files, setFiles] = useState<Record<number, FileState>>({});
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await applicationsApi.getForm();
+      setForm(res ?? null);
+    } catch {
+      setError('현재 모집 중인 지원서가 없어요.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const questions = useMemo(() => {
+    return (form?.questions ?? []).slice().sort((a, b) => {
+      const ao = a.questionOrder ?? 0;
+      const bo = b.questionOrder ?? 0;
+      return ao - bo;
+    });
+  }, [form?.questions]);
+
+  const notices = useMemo(() => form?.notices ?? [], [form?.notices]);
+
+  const handleAnswerChange = (id: number, value: AnswerValue) => {
+    setAnswers((prev) => ({ ...prev, [id]: value }));
+  };
+
+  const handleFileUpload = async (q: ApplicationQuestion, file: File) => {
+    const qid = q.formQuestionId;
+    setFiles((prev) => ({
+      ...prev,
+      [qid]: { ...prev[qid], uploading: true, error: null },
+    }));
+
+    try {
+      const res = await applicationsApi.presignFiles([
+        {
+          fileName: file.name,
+          contentType: file.type || 'application/octet-stream',
+        },
+      ]);
+      const target = res.items?.[0];
+      if (!target) throw new Error('업로드 URL이 없어요.');
+      await uploadToPresignedUrl(
+        target.uploadUrl,
+        file,
+        file.type || 'application/octet-stream',
+      );
+
+      setFiles((prev) => ({
+        ...prev,
+        [qid]: { key: target.key, uploading: false, error: null },
+      }));
+      handleAnswerChange(qid, target.key);
+    } catch {
+      setFiles((prev) => ({
+        ...prev,
+        [qid]: {
+          ...prev[qid],
+          uploading: false,
+          error: '파일 업로드에 실패했어요.',
+        },
+      }));
+    }
+  };
+
+  const handleSubmit = async () => {
+    setValidationError(null);
+
+    if (!studentId.trim() || !password.trim()) {
+      setValidationError('학번과 비밀번호를 입력해주세요.');
+      return;
+    }
+    if (!firstDepartment.trim() || !secondDepartment.trim()) {
+      setValidationError('1지망/2지망을 모두 입력해주세요.');
+      return;
+    }
+    if (firstDepartment.trim() === secondDepartment.trim()) {
+      setValidationError('1지망과 2지망은 서로 달라야 해요.');
+      return;
+    }
+
+    for (const q of questions) {
+      const val = normalizeAnswerValue(answers[q.formQuestionId] ?? null);
+      if (q.required && !val) {
+        setValidationError(
+          `필수 질문을 입력해주세요: ${q.content ?? ''}`.trim(),
+        );
+        return;
+      }
+      if (getAnswerType(q.answerType).includes('FILE')) {
+        const f = files[q.formQuestionId];
+        if (q.required && (!f || !f.key)) {
+          setValidationError(
+            `필수 파일을 업로드해주세요: ${q.content ?? ''}`.trim(),
+          );
+          return;
+        }
+      }
+    }
+
+    const payloadAnswers = questions
+      .map((q) => {
+        const value = normalizeAnswerValue(answers[q.formQuestionId] ?? null);
+        return value
+          ? { formQuestionId: q.formQuestionId, value }
+          : q.required
+            ? { formQuestionId: q.formQuestionId, value: '' }
+            : null;
+      })
+      .filter(Boolean) as Array<{
+      formQuestionId: number;
+      value: string | null;
+    }>;
+
+    setSubmitLoading(true);
+    try {
+      await applicationsApi.create({
+        studentId: studentId.trim(),
+        password: password.trim(),
+        firstDepartment: firstDepartment.trim(),
+        secondDepartment: secondDepartment.trim(),
+        answers: payloadAnswers,
+      });
+      alert('지원서가 제출되었습니다.');
+    } catch {
+      alert('지원서 제출에 실패했어요. 잠시 후 다시 시도해 주세요.');
+    } finally {
+      setSubmitLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-6xl px-4 py-12 text-sm text-slate-500">
+        불러오는 중...
+      </div>
+    );
+  }
+
+  if (error || !form) {
+    return (
+      <div className="mx-auto max-w-6xl px-4 py-12">
+        <h1 className="font-heading text-2xl text-slate-900">지원서 작성</h1>
+        <p className="mt-3 text-sm text-slate-600">
+          {error ?? '폼을 불러오지 못했어요.'}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-12">
+      <Reveal>
+        <h1 className="font-heading text-3xl text-primary">지원서 작성</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          모집 폼에 맞춰 지원서를 작성해 주세요.
+        </p>
+      </Reveal>
+
+      {validationError && (
+        <div className="mt-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-600">
+          {validationError}
+        </div>
+      )}
+
+      <Reveal
+        delayMs={120}
+        className="mt-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+      >
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <label className="text-sm font-bold text-slate-700">학번</label>
+            <input
+              value={studentId}
+              onChange={(e) => setStudentId(e.target.value)}
+              className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none focus:border-primary/60 focus:ring-4 focus:ring-primary/10"
+            />
+          </div>
+          <div>
+            <label className="text-sm font-bold text-slate-700">비밀번호</label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none focus:border-primary/60 focus:ring-4 focus:ring-primary/10"
+            />
+          </div>
+          <div>
+            <label className="text-sm font-bold text-slate-700">1지망</label>
+            <input
+              value={firstDepartment}
+              onChange={(e) => setFirstDepartment(e.target.value)}
+              className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none focus:border-primary/60 focus:ring-4 focus:ring-primary/10"
+            />
+          </div>
+          <div>
+            <label className="text-sm font-bold text-slate-700">2지망</label>
+            <input
+              value={secondDepartment}
+              onChange={(e) => setSecondDepartment(e.target.value)}
+              className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none focus:border-primary/60 focus:ring-4 focus:ring-primary/10"
+            />
+          </div>
+        </div>
+      </Reveal>
+
+      {notices.length > 0 && (
+        <Reveal
+          delayMs={180}
+          className="mt-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+        >
+          <h2 className="text-base font-bold text-slate-900">공지사항</h2>
+          <ul className="mt-3 space-y-3 text-sm text-slate-700">
+            {notices.map((n) => (
+              <li
+                key={String(n.noticeId)}
+                className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3"
+              >
+                <p className="text-sm font-semibold text-slate-900">
+                  {n.title}
+                </p>
+                <p className="mt-1 text-xs text-slate-600">{n.content}</p>
+              </li>
+            ))}
+          </ul>
+        </Reveal>
+      )}
+
+      <Reveal
+        delayMs={240}
+        className="mt-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+      >
+        <h2 className="text-base font-bold text-slate-900">질문</h2>
+
+        <div className="mt-4 space-y-5">
+          {questions.map((q) => {
+            const type = getAnswerType(q.answerType);
+            const value = answers[q.formQuestionId] ?? '';
+            const options = parseOptions(q.selectOptions);
+
+            return (
+              <div key={q.formQuestionId} className="space-y-2">
+                <label className="text-sm font-bold text-slate-700">
+                  {q.content}
+                  {q.required && <span className="ml-1 text-rose-500">*</span>}
+                </label>
+                {q.description && (
+                  <p className="text-xs text-slate-400">{q.description}</p>
+                )}
+
+                {type.includes('FILE') ? (
+                  <div className="flex flex-col gap-2">
+                    <input
+                      type="file"
+                      onChange={(e) => {
+                        const file = e.target.files?.[0];
+                        if (file) void handleFileUpload(q, file);
+                      }}
+                      className="text-sm"
+                    />
+                    {files[q.formQuestionId]?.uploading && (
+                      <span className="text-xs text-slate-500">
+                        업로드 중...
+                      </span>
+                    )}
+                    {files[q.formQuestionId]?.key && (
+                      <span className="text-xs text-emerald-600">
+                        업로드 완료
+                      </span>
+                    )}
+                    {files[q.formQuestionId]?.error && (
+                      <span className="text-xs text-rose-600">
+                        {files[q.formQuestionId]?.error}
+                      </span>
+                    )}
+                  </div>
+                ) : type.includes('TEXTAREA') ? (
+                  <textarea
+                    value={String(value ?? '')}
+                    onChange={(e) =>
+                      handleAnswerChange(q.formQuestionId, e.target.value)
+                    }
+                    className="min-h-[120px] w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none focus:border-primary/60 focus:ring-4 focus:ring-primary/10"
+                  />
+                ) : type.includes('SELECT') || type.includes('RADIO') ? (
+                  <select
+                    value={String(value ?? '')}
+                    onChange={(e) =>
+                      handleAnswerChange(q.formQuestionId, e.target.value)
+                    }
+                    className="w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none focus:border-primary/60 focus:ring-4 focus:ring-primary/10"
+                  >
+                    <option value="">선택</option>
+                    {options.map((opt) => (
+                      <option key={opt} value={opt}>
+                        {opt}
+                      </option>
+                    ))}
+                  </select>
+                ) : type.includes('CHECK') || type.includes('MULTI') ? (
+                  <div className="flex flex-wrap gap-2">
+                    {options.map((opt) => {
+                      const arr = Array.isArray(value) ? value : [];
+                      const checked = arr.includes(opt);
+                      return (
+                        <label
+                          key={opt}
+                          className="flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-700"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={(e) => {
+                              const next = new Set(arr);
+                              if (e.target.checked) next.add(opt);
+                              else next.delete(opt);
+                              handleAnswerChange(
+                                q.formQuestionId,
+                                Array.from(next),
+                              );
+                            }}
+                          />
+                          {opt}
+                        </label>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <input
+                    value={String(value ?? '')}
+                    onChange={(e) =>
+                      handleAnswerChange(q.formQuestionId, e.target.value)
+                    }
+                    className="w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none focus:border-primary/60 focus:ring-4 focus:ring-primary/10"
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="mt-6 flex justify-end">
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitLoading}
+            className="rounded-xl bg-primary px-5 py-2.5 text-sm font-bold text-white shadow-lg transition hover:opacity-95 disabled:opacity-60"
+          >
+            {submitLoading ? '제출 중...' : '지원서 제출'}
+          </button>
+        </div>
+      </Reveal>
+    </div>
+  );
+}


### PR DESCRIPTION
#60 

## 요약
- 사용자 지원서 작성/수정/결과 조회 플로우를 신규 구현
- 지원서 Form 조회/제출/수정/결과 조회 API 연동
- 파일 첨부는 presigned URL 업로드로 처리

## 변경 사항
- 지원서 작성 페이지 추가
- 지원서 수정(학번+비밀번호 인증) 페이지 추가
- 지원 결과 조회 페이지 추가
- 라우팅 및 메뉴(APPLY 경로) 연결

## 테스트
- [ ] 로컬에서 /apply 접속 시 폼 로딩 확인
- [ ] 학번/비밀번호로 수정 조회 동작 확인
- [ ] 결과 조회 동작 확인
- [ ] 파일 첨부 업로드 동작 확인

## 참고/제약
- 서버에서 OPEN 폼이 없으면 화면에 “현재 모집 중인 지원서가 없어요.”만 표시됨
- 관리자용 지원서 관리 기능은 별도 이슈에서 진행