### PR TITLE
Fix: 주문 흐름 라우팅 정리 및 주문 조회/상세 오류 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import SiteLayout from './components/SiteLayout';
 import AdminLayout from './components/AdminLayout';
 import MainPage from './pages/site/MainPage';
@@ -11,6 +11,11 @@ import ProjectDetailPage from './pages/site/ProjectDetailPage';
 import ProjectItemDetailPage from './pages/site/ProjectItemDetailPage';
 import ResourcesPage from './pages/site/ResourcesPage';
 import SettlementsPage from './pages/site/SettlementsPage';
+import CartPage from './pages/site/CartPage';
+import OrderPage from './pages/site/OrderPage';
+import OrderCompletePage from './pages/site/OrderCompletePage';
+import OrderLookupPage from './pages/site/OrderLookupPage';
+import OrderViewPage from './pages/site/OrderViewPage';
 import LoginPage from './pages/site/LoginPage';
 import OAuthCallbackPage from './pages/site/OAuthCallbackPage';
 import AdminDashboardPage from './pages/admin/AdminDashboardPage';
@@ -19,6 +24,7 @@ import AdminProjectEditorPage from './pages/admin/AdminProjectEditorPage';
 import AdminProjectItemsListPage from './pages/admin/AdminProjectItemsListPage';
 import AdminProjectItemCreatePage from './pages/admin/AdminProjectItemCreatePage';
 import AdminItemDetailPage from './pages/admin/AdminItemDetailPage';
+import AdminOrdersPage from './pages/admin/AdminOrdersPage';
 import AdminNoticesListPage from './pages/admin/AdminNoticesListPage';
 import AdminNoticeEditorPage from './pages/admin/AdminNoticeEditorPage';
 import AdminNoticeDetailPage from './pages/admin/AdminNoticeDetailPage';
@@ -27,6 +33,11 @@ import AdminApplicationDetailPage from './pages/admin/AdminApplicationDetailPage
 import FloatingSns from './components/FloatingSns';
 
 export default function App() {
+  const location = useLocation();
+  const hideFloatingSns =
+    location.pathname.startsWith('/order') ||
+    location.pathname.startsWith('/orders');
+
   return (
     <>
       <Routes>
@@ -39,6 +50,11 @@ export default function App() {
             element={<ProjectItemDetailPage />}
           />
           <Route path="/resources" element={<ResourcesPage />} />
+          <Route path="/cart" element={<CartPage />} />
+          <Route path="/order" element={<OrderPage />} />
+          <Route path="/order/complete" element={<OrderCompletePage />} />
+          <Route path="/orders/lookup" element={<OrderLookupPage />} />
+          <Route path="/orders/view" element={<OrderViewPage />} />
           <Route path="/settlements" element={<SettlementsPage />} />
           <Route path="/about" element={<AboutPage />} />
           <Route path="/forms" element={<FormPage />} />
@@ -72,6 +88,7 @@ export default function App() {
             path="/admin/items/:itemId"
             element={<AdminItemDetailPage />}
           />
+          <Route path="/admin/orders" element={<AdminOrdersPage />} />
           <Route path="/admin/notices" element={<AdminNoticesListPage />} />
           <Route
             path="/admin/notices/new"
@@ -95,8 +112,7 @@ export default function App() {
           />
         </Route>
       </Routes>
-
-      <FloatingSns />
+      {!hideFloatingSns && <FloatingSns />}
     </>
   );
 }

--- a/src/api/adminOrders.ts
+++ b/src/api/adminOrders.ts
@@ -231,7 +231,11 @@ function toDetail(raw: unknown): AdminOrderDetail {
           ),
           createdAt: pickDateTime(orderRecord, 'createdAt', 'created_at'),
           canceledAt: pickDateTime(orderRecord, 'canceledAt', 'canceled_at'),
-          cancelReason: pickString(orderRecord, 'cancelReason', 'cancel_reason'),
+          cancelReason: pickString(
+            orderRecord,
+            'cancelReason',
+            'cancel_reason',
+          ),
           refundRequestedAt: pickDateTime(
             orderRecord,
             'refundRequestedAt',
@@ -239,7 +243,11 @@ function toDetail(raw: unknown): AdminOrderDetail {
           ),
           refundedAt: pickDateTime(orderRecord, 'refundedAt', 'refunded_at'),
           paidAt: pickDateTime(orderRecord, 'paidAt', 'paid_at'),
-          depositorName: pickString(orderRecord, 'depositorName', 'depositor_name'),
+          depositorName: pickString(
+            orderRecord,
+            'depositorName',
+            'depositor_name',
+          ),
         }
       : undefined,
     buyer: buyerRecord
@@ -256,7 +264,11 @@ function toDetail(raw: unknown): AdminOrderDetail {
           ),
           studentNo: pickString(buyerRecord, 'studentNo', 'student_no'),
           refundBank: pickString(buyerRecord, 'refundBank', 'refund_bank'),
-          refundAccount: pickString(buyerRecord, 'refundAccount', 'refund_account'),
+          refundAccount: pickString(
+            buyerRecord,
+            'refundAccount',
+            'refund_account',
+          ),
           referralSource: pickString(
             buyerRecord,
             'referralSource',
@@ -282,10 +294,26 @@ function toDetail(raw: unknown): AdminOrderDetail {
             'infoConfirmed',
             'info_confirmed',
           ),
-          postalCode: pickString(fulfillmentRecord, 'postalCode', 'postal_code'),
-          addressLine1: pickString(fulfillmentRecord, 'addressLine1', 'address_line1'),
-          addressLine2: pickString(fulfillmentRecord, 'addressLine2', 'address_line2'),
-          deliveryMemo: pickString(fulfillmentRecord, 'deliveryMemo', 'delivery_memo'),
+          postalCode: pickString(
+            fulfillmentRecord,
+            'postalCode',
+            'postal_code',
+          ),
+          addressLine1: pickString(
+            fulfillmentRecord,
+            'addressLine1',
+            'address_line1',
+          ),
+          addressLine2: pickString(
+            fulfillmentRecord,
+            'addressLine2',
+            'address_line2',
+          ),
+          deliveryMemo: pickString(
+            fulfillmentRecord,
+            'deliveryMemo',
+            'delivery_memo',
+          ),
         }
       : undefined,
     items,

--- a/src/api/items.ts
+++ b/src/api/items.ts
@@ -52,11 +52,8 @@ export const itemsApi = {
   getJournalDownloadUrl(itemId: string) {
     return api<
       ApiResult<ItemJournalDownloadResponse> | ItemJournalDownloadResponse
-    >(
-      withApiBase(`/items/${itemId}/journal/presign-get`),
-      {
-        method: 'POST',
-      },
-    ).then((res) => unwrapApiResult(res));
+    >(withApiBase(`/items/${itemId}/journal/presign-get`), {
+      method: 'POST',
+    }).then((res) => unwrapApiResult(res));
   },
 };

--- a/src/api/orders.ts
+++ b/src/api/orders.ts
@@ -156,33 +156,33 @@ function toOrderCreateResponse(raw: unknown): OrderCreateResponse {
       typeof record.orderId === 'number'
         ? record.orderId
         : typeof record.order_id === 'number'
-        ? record.order_id
-        : undefined,
+          ? record.order_id
+          : undefined,
     orderNo:
       typeof record.orderNo === 'string'
         ? record.orderNo
         : typeof record.order_no === 'string'
-        ? record.order_no
-        : undefined,
+          ? record.order_no
+          : undefined,
     status: typeof record.status === 'string' ? record.status : undefined,
     totalAmount:
       typeof record.totalAmount === 'number'
         ? record.totalAmount
         : typeof record.total_amount === 'number'
-        ? record.total_amount
-        : undefined,
+          ? record.total_amount
+          : undefined,
     shippingFee:
       typeof record.shippingFee === 'number'
         ? record.shippingFee
         : typeof record.shipping_fee === 'number'
-        ? record.shipping_fee
-        : undefined,
+          ? record.shipping_fee
+          : undefined,
     finalAmount:
       typeof record.finalAmount === 'number'
         ? record.finalAmount
         : typeof record.final_amount === 'number'
-        ? record.final_amount
-        : undefined,
+          ? record.final_amount
+          : undefined,
     depositDeadline: normalizeDateValue(
       record.depositDeadline ?? record.deposit_deadline,
     ),
@@ -190,14 +190,14 @@ function toOrderCreateResponse(raw: unknown): OrderCreateResponse {
       typeof record.lookupId === 'string'
         ? record.lookupId
         : typeof record.lookup_id === 'string'
-        ? record.lookup_id
-        : undefined,
+          ? record.lookup_id
+          : undefined,
     viewToken:
       typeof record.viewToken === 'string'
         ? record.viewToken
         : typeof record.view_token === 'string'
-        ? record.view_token
-        : undefined,
+          ? record.view_token
+          : undefined,
     raw,
   };
 }
@@ -302,7 +302,12 @@ function toOrderDetailItem(raw: unknown): OrderDetailItem | null {
   const record = asRecord(raw);
   if (!record) return null;
   return {
-    projectItemId: pickNumber(record, 'projectItemId', 'project_item_id', 'itemId'),
+    projectItemId: pickNumber(
+      record,
+      'projectItemId',
+      'project_item_id',
+      'itemId',
+    ),
     itemName: pickString(
       record,
       'itemName',
@@ -380,7 +385,11 @@ function toOrderDetailResponse(raw: unknown): OrderDetailResponse {
           studentNo: pickString(buyerRecord, 'studentNo', 'student_no'),
           phone: pickString(buyerRecord, 'phone'),
           refundBank: pickString(buyerRecord, 'refundBank', 'refund_bank'),
-          refundAccount: pickString(buyerRecord, 'refundAccount', 'refund_account'),
+          refundAccount: pickString(
+            buyerRecord,
+            'refundAccount',
+            'refund_account',
+          ),
           referralSource: pickString(
             buyerRecord,
             'referralSource',
@@ -407,10 +416,26 @@ function toOrderDetailResponse(raw: unknown): OrderDetailResponse {
             'infoConfirmed',
             'info_confirmed',
           ),
-          postalCode: pickString(fulfillmentRecord, 'postalCode', 'postal_code'),
-          addressLine1: pickString(fulfillmentRecord, 'addressLine1', 'address_line1'),
-          addressLine2: pickString(fulfillmentRecord, 'addressLine2', 'address_line2'),
-          deliveryMemo: pickString(fulfillmentRecord, 'deliveryMemo', 'delivery_memo'),
+          postalCode: pickString(
+            fulfillmentRecord,
+            'postalCode',
+            'postal_code',
+          ),
+          addressLine1: pickString(
+            fulfillmentRecord,
+            'addressLine1',
+            'address_line1',
+          ),
+          addressLine2: pickString(
+            fulfillmentRecord,
+            'addressLine2',
+            'address_line2',
+          ),
+          deliveryMemo: pickString(
+            fulfillmentRecord,
+            'deliveryMemo',
+            'delivery_memo',
+          ),
         }
       : undefined,
     items,
@@ -430,10 +455,13 @@ export const ordersApi = {
   },
 
   async createOrder(payload: OrderCreateRequest) {
-    const data = await api<ApiResult<unknown> | unknown>(withApiBase('/orders'), {
-      method: 'POST',
-      body: payload,
-    });
+    const data = await api<ApiResult<unknown> | unknown>(
+      withApiBase('/orders'),
+      {
+        method: 'POST',
+        body: payload,
+      },
+    );
     return toOrderCreateResponse(unwrapApiResult(data));
   },
 

--- a/src/components/AdminHeaderDesktop.tsx
+++ b/src/components/AdminHeaderDesktop.tsx
@@ -9,6 +9,7 @@ const NAV_ITEMS = [
   { key: 'about', label: '소개', href: '/admin#about?tab=main' },
   { key: 'links', label: '링크', href: '/admin#links' },
   { key: 'projects', label: '프로젝트/상품', href: '/admin/projects' },
+  { key: 'orders', label: '주문', href: '/admin/orders' },
   { key: 'notices', label: '공지사항', href: '/admin/notices' },
   { key: 'applications', label: '지원서', href: '/admin/applications' },
   { key: 'settlements', label: '정산', href: '/admin#settlements' },
@@ -31,11 +32,13 @@ export default function AdminHeaderDesktop() {
     location.pathname.startsWith('/admin/projects') ||
     location.pathname.startsWith('/admin/items')
       ? 'projects'
-      : location.pathname.startsWith('/admin/notices')
-        ? 'notices'
-        : location.pathname.startsWith('/admin/applications')
-          ? 'applications'
-          : normalizedActive;
+      : location.pathname.startsWith('/admin/orders')
+        ? 'orders'
+        : location.pathname.startsWith('/admin/notices')
+          ? 'notices'
+          : location.pathname.startsWith('/admin/applications')
+            ? 'applications'
+            : normalizedActive;
 
   return (
     <div className="mx-auto hidden max-w-none grid-cols-[1fr_auto_1fr] items-center px-6 py-4 md:grid">

--- a/src/components/AdminHeaderMobile.tsx
+++ b/src/components/AdminHeaderMobile.tsx
@@ -9,6 +9,7 @@ const NAV_ITEMS = [
   { key: 'about', label: '소개', href: '/admin#about?tab=main' },
   { key: 'links', label: '링크', href: '/admin#links' },
   { key: 'projects', label: '프로젝트/상품', href: '/admin/projects' },
+  { key: 'orders', label: '주문', href: '/admin/orders' },
   { key: 'notices', label: '공지사항', href: '/admin/notices' },
   { key: 'applications', label: '지원서', href: '/admin/applications' },
   { key: 'settlements', label: '정산', href: '/admin#settlements' },

--- a/src/components/HeaderDesktop.tsx
+++ b/src/components/HeaderDesktop.tsx
@@ -2,12 +2,13 @@ import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 
-type MenuKey = 'projects' | null;
+type MenuKey = 'projects' | 'order' | null;
 
 export default function HeaderDesktop() {
   const navigate = useNavigate();
   const [open, setOpen] = useState<MenuKey>(null);
   const isProjectsOpen = open === 'projects';
+  const isOrderOpen = open === 'order';
   const { isLoggedIn } = useAuth();
 
   return (
@@ -83,14 +84,6 @@ export default function HeaderDesktop() {
       </Link>
 
       <Link
-        to="/resources"
-        onClick={() => setOpen(null)}
-        className="rounded-lg px-3 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-100 hover:text-primary"
-      >
-        FREE RESOURCES
-      </Link>
-
-      <Link
         to="/settlements"
         onClick={() => setOpen(null)}
         className="rounded-lg px-3 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-100 hover:text-primary"
@@ -113,6 +106,58 @@ export default function HeaderDesktop() {
       >
         CONTACT
       </Link>
+
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => setOpen(isOrderOpen ? null : 'order')}
+          className="rounded-lg px-3 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-100 hover:text-primary"
+          aria-expanded={isOrderOpen}
+          aria-haspopup="menu"
+        >
+          ORDER <span className="ml-1 text-slate-400">▾</span>
+        </button>
+
+        {isOrderOpen && (
+          <button
+            type="button"
+            aria-label="close dropdown"
+            className="fixed inset-0 z-40 cursor-default"
+            onClick={() => setOpen(null)}
+          />
+        )}
+
+        <div
+          className={[
+            'absolute right-0 z-50 mt-2 w-52 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-lg',
+            'transition-all duration-200 ease-out',
+            isOrderOpen
+              ? 'pointer-events-auto translate-y-0 opacity-100'
+              : 'pointer-events-none -translate-y-1 opacity-0',
+          ].join(' ')}
+          role="menu"
+        >
+          <div className="py-2">
+            {[
+              { label: 'CART', href: '/cart' },
+              { label: 'ORDER LOOKUP', href: '/orders/lookup' },
+            ].map((x) => (
+              <button
+                key={x.href}
+                type="button"
+                onClick={() => {
+                  setOpen(null);
+                  navigate(x.href);
+                }}
+                className="w-full px-4 py-2 text-left text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100 hover:text-primary"
+                role="menuitem"
+              >
+                {x.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
 
       <button
         type="button"

--- a/src/components/HeaderMobile.tsx
+++ b/src/components/HeaderMobile.tsx
@@ -240,7 +240,6 @@ export default function HeaderMobile() {
             </div>
 
             {[
-              { label: 'FREE RESOURCES', href: '/resources' },
               { label: 'APPLY', href: '/apply' },
               { label: 'CONTACT', href: '/contact' },
               { label: 'PAYOUTS', href: '/settlements' },

--- a/src/components/order/OrderDetailCard.tsx
+++ b/src/components/order/OrderDetailCard.tsx
@@ -42,7 +42,11 @@ function formatDateTime(value?: string) {
   return `${yyyy}-${mm}-${dd} ${hh}:${mi}`;
 }
 
-export default function OrderDetailCard({ order }: { order: OrderDetailResponse }) {
+export default function OrderDetailCard({
+  order,
+}: {
+  order: OrderDetailResponse;
+}) {
   const inferredTotalAmount = order.items.reduce((sum, item) => {
     if (typeof item.lineAmount === 'number') return sum + item.lineAmount;
     if (
@@ -54,18 +58,22 @@ export default function OrderDetailCard({ order }: { order: OrderDetailResponse 
     return sum;
   }, 0);
   const totalAmountToShow =
-    order.totalAmount !== undefined ? order.totalAmount : inferredTotalAmount || undefined;
+    order.totalAmount !== undefined
+      ? order.totalAmount
+      : inferredTotalAmount || undefined;
   const finalAmountToShow =
     order.finalAmount !== undefined
       ? order.finalAmount
       : totalAmountToShow !== undefined && order.shippingFee !== undefined
-      ? totalAmountToShow + order.shippingFee
-      : totalAmountToShow;
+        ? totalAmountToShow + order.shippingFee
+        : totalAmountToShow;
   const basicRows = [
     { label: '주문번호', value: order.orderNo },
     {
       label: '주문상태',
-      value: order.status ? STATUS_LABELS[order.status] ?? order.status : undefined,
+      value: order.status
+        ? (STATUS_LABELS[order.status] ?? order.status)
+        : undefined,
     },
     { label: '총 상품금액', value: formatMoney(totalAmountToShow) },
     { label: '배송비', value: formatMoney(order.shippingFee) },
@@ -79,7 +87,9 @@ export default function OrderDetailCard({ order }: { order: OrderDetailResponse 
         <h2 className="text-lg font-bold text-slate-900">주문 기본 정보</h2>
         <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2 text-sm text-slate-700">
           {basicRows.length === 0 ? (
-            <div className="rounded-xl bg-slate-50 px-3 py-2">표시 가능한 기본 정보가 없어요.</div>
+            <div className="rounded-xl bg-slate-50 px-3 py-2">
+              표시 가능한 기본 정보가 없어요.
+            </div>
           ) : (
             basicRows.map((row) => (
               <div
@@ -96,7 +106,9 @@ export default function OrderDetailCard({ order }: { order: OrderDetailResponse 
       <section className="rounded-2xl border border-slate-200 bg-white p-5">
         <h3 className="text-sm font-bold text-slate-900">주문 상품</h3>
         {order.items.length === 0 ? (
-          <p className="mt-2 text-sm text-slate-500">주문 상품 정보가 없어요.</p>
+          <p className="mt-2 text-sm text-slate-500">
+            주문 상품 정보가 없어요.
+          </p>
         ) : (
           <div className="mt-3 space-y-2">
             {order.items.map((item, index) => (
@@ -105,7 +117,8 @@ export default function OrderDetailCard({ order }: { order: OrderDetailResponse 
                 className="flex items-center justify-between rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm"
               >
                 <span className="text-slate-700">
-                  {item.itemName ?? `상품 #${item.projectItemId ?? '-'}`} x {item.quantity ?? '-'}
+                  {item.itemName ?? `상품 #${item.projectItemId ?? '-'}`} x{' '}
+                  {item.quantity ?? '-'}
                 </span>
                 <span className="font-semibold text-slate-900">
                   {formatMoney(item.lineAmount)}
@@ -125,20 +138,24 @@ export default function OrderDetailCard({ order }: { order: OrderDetailResponse 
           <div className="rounded-xl bg-slate-50 px-3 py-2">
             구매자 구분:{' '}
             {order.buyer?.buyerType
-              ? BUYER_TYPE_LABELS[order.buyer.buyerType] ?? order.buyer.buyerType
+              ? (BUYER_TYPE_LABELS[order.buyer.buyerType] ??
+                order.buyer.buyerType)
               : '-'}
           </div>
           <div className="rounded-xl bg-slate-50 px-3 py-2">
             캠퍼스:{' '}
             {order.buyer?.campus
-              ? CAMPUS_LABELS[order.buyer.campus] ?? order.buyer.campus
+              ? (CAMPUS_LABELS[order.buyer.campus] ?? order.buyer.campus)
               : '-'}
           </div>
-          <div className="rounded-xl bg-slate-50 px-3 py-2">연락처: {order.buyer?.phone ?? '-'}</div>
+          <div className="rounded-xl bg-slate-50 px-3 py-2">
+            연락처: {order.buyer?.phone ?? '-'}
+          </div>
           <div className="rounded-xl bg-slate-50 px-3 py-2">
             수령 방식:{' '}
             {order.fulfillment?.method
-              ? FULFILLMENT_LABELS[order.fulfillment.method] ?? order.fulfillment.method
+              ? (FULFILLMENT_LABELS[order.fulfillment.method] ??
+                order.fulfillment.method)
               : '-'}
           </div>
           <div className="rounded-xl bg-slate-50 px-3 py-2">

--- a/src/pages/admin/AdminOrdersPage.tsx
+++ b/src/pages/admin/AdminOrdersPage.tsx
@@ -10,14 +10,15 @@ import {
   type AdminOrderStatus,
 } from '../../api/adminOrders';
 
-const STATUS_FILTERS: Array<{ key: 'ALL' | AdminOrderStatus; label: string }> = [
-  { key: 'ALL', label: '전체' },
-  { key: 'PENDING_DEPOSIT', label: '입금 확인 필요' },
-  { key: 'PAID', label: '입금 확인 완료' },
-  { key: 'CANCELED', label: '취소' },
-  { key: 'REFUND_REQUESTED', label: '환불 요청' },
-  { key: 'REFUNDED', label: '환불 완료' },
-];
+const STATUS_FILTERS: Array<{ key: 'ALL' | AdminOrderStatus; label: string }> =
+  [
+    { key: 'ALL', label: '전체' },
+    { key: 'PENDING_DEPOSIT', label: '입금 확인 필요' },
+    { key: 'PAID', label: '입금 확인 완료' },
+    { key: 'CANCELED', label: '취소' },
+    { key: 'REFUND_REQUESTED', label: '환불 요청' },
+    { key: 'REFUNDED', label: '환불 완료' },
+  ];
 
 const STATUS_LABELS: Record<string, string> = {
   PENDING_DEPOSIT: '입금 확인 필요',
@@ -59,8 +60,12 @@ function formatDateTime(value?: string) {
   }).format(date);
 }
 
-function infoRows(rows: Array<{ label: string; value?: string | number | boolean }>) {
-  return rows.filter((row) => row.value !== undefined && row.value !== null && row.value !== '');
+function infoRows(
+  rows: Array<{ label: string; value?: string | number | boolean }>,
+) {
+  return rows.filter(
+    (row) => row.value !== undefined && row.value !== null && row.value !== '',
+  );
 }
 
 function toErrorMessage(error: unknown, fallback: string) {
@@ -114,7 +119,9 @@ export default function AdminOrdersPage() {
     setLoading(true);
     setError(null);
     try {
-      const list = await adminOrdersApi.list(filter === 'ALL' ? undefined : filter);
+      const list = await adminOrdersApi.list(
+        filter === 'ALL' ? undefined : filter,
+      );
       setOrders(list);
       if (list.length === 0) {
         setSelectedOrderId(null);
@@ -136,19 +143,22 @@ export default function AdminOrdersPage() {
     }
   }, [filter]);
 
-  const loadDetail = useCallback(async (orderId: number) => {
-    setDetailLoading(true);
-    try {
-      const data = await adminOrdersApi.getById(orderId);
-      setDetail(data);
-    } catch (err) {
-      console.error(err);
-      toast.error(toErrorMessage(err, '주문 상세를 불러오지 못했어요.'));
-      setDetail(null);
-    } finally {
-      setDetailLoading(false);
-    }
-  }, [toast]);
+  const loadDetail = useCallback(
+    async (orderId: number) => {
+      setDetailLoading(true);
+      try {
+        const data = await adminOrdersApi.getById(orderId);
+        setDetail(data);
+      } catch (err) {
+        console.error(err);
+        toast.error(toErrorMessage(err, '주문 상세를 불러오지 못했어요.'));
+        setDetail(null);
+      } finally {
+        setDetailLoading(false);
+      }
+    },
+    [toast],
+  );
 
   useEffect(() => {
     void loadOrders();
@@ -267,13 +277,14 @@ export default function AdminOrdersPage() {
         {
           label: '구매자 구분',
           value: detail?.buyer?.buyerType
-            ? BUYER_TYPE_LABELS[detail.buyer.buyerType] ?? detail.buyer.buyerType
+            ? (BUYER_TYPE_LABELS[detail.buyer.buyerType] ??
+              detail.buyer.buyerType)
             : undefined,
         },
         {
           label: '캠퍼스',
           value: detail?.buyer?.campus
-            ? CAMPUS_LABELS[detail.buyer.campus] ?? detail.buyer.campus
+            ? (CAMPUS_LABELS[detail.buyer.campus] ?? detail.buyer.campus)
             : undefined,
         },
         { label: '연락처', value: detail?.buyer?.phone },
@@ -293,7 +304,8 @@ export default function AdminOrdersPage() {
         {
           label: '수령 방식',
           value: detail?.fulfillment?.method
-            ? METHOD_LABELS[detail.fulfillment.method] ?? detail.fulfillment.method
+            ? (METHOD_LABELS[detail.fulfillment.method] ??
+              detail.fulfillment.method)
             : undefined,
         },
         { label: '수령자', value: detail?.fulfillment?.receiverName },
@@ -469,7 +481,9 @@ export default function AdminOrdersPage() {
                 목록에서 주문을 선택해주세요.
               </p>
             ) : detailLoading ? (
-              <p className="mt-4 text-sm text-slate-500">상세를 불러오는 중...</p>
+              <p className="mt-4 text-sm text-slate-500">
+                상세를 불러오는 중...
+              </p>
             ) : !detail ? (
               <p className="mt-4 text-sm text-rose-600">
                 주문 상세를 불러오지 못했습니다.
@@ -499,16 +513,21 @@ export default function AdminOrdersPage() {
                   <div className="rounded-xl bg-slate-50 px-3 py-2">
                     입금 마감:{' '}
                     {formatDateTime(
-                      detail.order?.depositDeadline ?? selectedOrder?.depositDeadline,
+                      detail.order?.depositDeadline ??
+                        selectedOrder?.depositDeadline,
                     )}
                   </div>
                   <div className="rounded-xl bg-slate-50 px-3 py-2">
                     입금자명:{' '}
-                    {detail.order?.depositorName ?? selectedOrder?.depositorName ?? '-'}
+                    {detail.order?.depositorName ??
+                      selectedOrder?.depositorName ??
+                      '-'}
                   </div>
                   <div className="rounded-xl bg-slate-50 px-3 py-2">
                     주문일:{' '}
-                    {formatDateTime(detail.order?.createdAt ?? selectedOrder?.createdAt)}
+                    {formatDateTime(
+                      detail.order?.createdAt ?? selectedOrder?.createdAt,
+                    )}
                   </div>
                 </div>
 
@@ -529,8 +548,8 @@ export default function AdminOrdersPage() {
                         type="button"
                         onClick={() => void handleConfirmPaid()}
                         disabled={actionLoading}
-                      className="rounded-xl bg-emerald-600 px-3 py-2 text-sm font-semibold text-white hover:bg-emerald-500 disabled:opacity-60"
-                    >
+                        className="rounded-xl bg-emerald-600 px-3 py-2 text-sm font-semibold text-white hover:bg-emerald-500 disabled:opacity-60"
+                      >
                         입금 확인
                       </button>
                       <button
@@ -566,10 +585,14 @@ export default function AdminOrdersPage() {
                 </div>
 
                 <div className="mt-6">
-                  <h3 className="text-sm font-bold text-slate-900">주문 상품</h3>
+                  <h3 className="text-sm font-bold text-slate-900">
+                    주문 상품
+                  </h3>
                   <div className="mt-2 space-y-2">
                     {detail.items.length === 0 ? (
-                      <p className="text-sm text-slate-500">주문 상품이 없습니다.</p>
+                      <p className="text-sm text-slate-500">
+                        주문 상품이 없습니다.
+                      </p>
                     ) : (
                       detail.items.map((item, index) => (
                         <div
@@ -577,11 +600,13 @@ export default function AdminOrdersPage() {
                           className="rounded-xl bg-slate-50 px-3 py-2 text-sm"
                         >
                           <p className="font-semibold text-slate-800">
-                            {item.itemName ?? `상품 #${item.projectItemId ?? '-'}`}
+                            {item.itemName ??
+                              `상품 #${item.projectItemId ?? '-'}`}
                           </p>
                           <p className="text-slate-600">
-                            수량 {item.quantity ?? '-'} / 단가 {formatMoney(item.unitPrice)} /
-                            금액 {formatMoney(item.lineAmount)}
+                            수량 {item.quantity ?? '-'} / 단가{' '}
+                            {formatMoney(item.unitPrice)} / 금액{' '}
+                            {formatMoney(item.lineAmount)}
                           </p>
                         </div>
                       ))
@@ -590,13 +615,20 @@ export default function AdminOrdersPage() {
                 </div>
 
                 <div className="mt-6">
-                  <h3 className="text-sm font-bold text-slate-900">구매자 정보</h3>
+                  <h3 className="text-sm font-bold text-slate-900">
+                    구매자 정보
+                  </h3>
                   <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
                     {buyerRows.length === 0 ? (
-                      <p className="text-sm text-slate-500">구매자 정보가 없습니다.</p>
+                      <p className="text-sm text-slate-500">
+                        구매자 정보가 없습니다.
+                      </p>
                     ) : (
                       buyerRows.map((row) => (
-                        <div key={row.label} className="rounded-xl bg-slate-50 px-3 py-2 text-sm">
+                        <div
+                          key={row.label}
+                          className="rounded-xl bg-slate-50 px-3 py-2 text-sm"
+                        >
                           {row.label}: {String(row.value)}
                         </div>
                       ))
@@ -605,13 +637,20 @@ export default function AdminOrdersPage() {
                 </div>
 
                 <div className="mt-6">
-                  <h3 className="text-sm font-bold text-slate-900">수령 정보</h3>
+                  <h3 className="text-sm font-bold text-slate-900">
+                    수령 정보
+                  </h3>
                   <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
                     {fulfillmentRows.length === 0 ? (
-                      <p className="text-sm text-slate-500">수령 정보가 없습니다.</p>
+                      <p className="text-sm text-slate-500">
+                        수령 정보가 없습니다.
+                      </p>
                     ) : (
                       fulfillmentRows.map((row) => (
-                        <div key={row.label} className="rounded-xl bg-slate-50 px-3 py-2 text-sm">
+                        <div
+                          key={row.label}
+                          className="rounded-xl bg-slate-50 px-3 py-2 text-sm"
+                        >
                           {row.label}: {String(row.value)}
                         </div>
                       ))

--- a/src/pages/site/CartPage.tsx
+++ b/src/pages/site/CartPage.tsx
@@ -109,7 +109,9 @@ export default function CartPage() {
 
       {items.length === 0 ? (
         <Reveal className="mt-6 rounded-3xl border border-slate-200 bg-white p-8 text-center">
-          <p className="text-sm font-semibold text-slate-500">장바구니가 비어 있어요.</p>
+          <p className="text-sm font-semibold text-slate-500">
+            장바구니가 비어 있어요.
+          </p>
           <Link
             to="/projects"
             className="mt-4 inline-flex h-11 items-center justify-center rounded-2xl bg-primary px-5 text-sm font-semibold text-white hover:opacity-95"
@@ -170,7 +172,10 @@ export default function CartPage() {
                           <button
                             type="button"
                             onClick={() =>
-                              setCartItemQuantity(item.itemId, Math.max(1, item.quantity - 1))
+                              setCartItemQuantity(
+                                item.itemId,
+                                Math.max(1, item.quantity - 1),
+                              )
                             }
                             className="h-8 w-8 text-sm font-bold text-slate-700 hover:bg-slate-50"
                             aria-label="수량 감소"
@@ -182,7 +187,12 @@ export default function CartPage() {
                           </span>
                           <button
                             type="button"
-                            onClick={() => setCartItemQuantity(item.itemId, item.quantity + 1)}
+                            onClick={() =>
+                              setCartItemQuantity(
+                                item.itemId,
+                                item.quantity + 1,
+                              )
+                            }
                             className="h-8 w-8 text-sm font-bold text-slate-700 hover:bg-slate-50"
                             aria-label="수량 증가"
                           >
@@ -191,7 +201,8 @@ export default function CartPage() {
                         </div>
                         {item.mergedByDuplicateAdd && (
                           <p className="mt-2 text-[11px] font-semibold text-primary">
-                            동일한 상품을 추가로 담아 기존에 담긴 상품 수량이 변경되었어요.
+                            동일한 상품을 추가로 담아 기존에 담긴 상품 수량이
+                            변경되었어요.
                             <button
                               type="button"
                               onClick={() => clearMergedNotice(item.itemId)}
@@ -232,7 +243,8 @@ export default function CartPage() {
               <div className="mt-5 space-y-2">
                 {hasNonOpenItem && (
                   <p className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-xs font-semibold text-rose-700">
-                    진행중이 아닌 상품이 포함되어 있어요. 해당 상품을 삭제한 뒤 주문해주세요.
+                    진행중이 아닌 상품이 포함되어 있어요. 해당 상품을 삭제한 뒤
+                    주문해주세요.
                   </p>
                 )}
                 <button

--- a/src/pages/site/OrderCompletePage.tsx
+++ b/src/pages/site/OrderCompletePage.tsx
@@ -23,13 +23,15 @@ export default function OrderCompletePage() {
   const state = (location.state ?? {}) as OrderCompleteState;
 
   const statusLabel = state.status
-    ? STATUS_LABELS[state.status] ?? state.status
+    ? (STATUS_LABELS[state.status] ?? state.status)
     : '-';
   const depositDeadlineText = resolveDepositDeadlineText(
     state.depositDeadline,
     state.orderNo,
   );
-  const canCopyLookupId = Boolean(state.lookupId && state.lookupId.trim().length > 0);
+  const canCopyLookupId = Boolean(
+    state.lookupId && state.lookupId.trim().length > 0,
+  );
 
   const copyLookupId = async () => {
     if (!canCopyLookupId) return;
@@ -48,7 +50,9 @@ export default function OrderCompletePage() {
           <p className="inline-flex rounded-full border border-emerald-200 bg-white px-3 py-1 text-xs font-bold text-emerald-700">
             ORDER RECEIVED
           </p>
-          <h1 className="mt-3 font-heading text-3xl text-emerald-900">주문이 접수되었어요</h1>
+          <h1 className="mt-3 font-heading text-3xl text-emerald-900">
+            주문이 접수되었어요
+          </h1>
           <p className="mt-2 text-sm text-emerald-800">
             아래 입금 마감 시간 전까지 입금을 완료하면 주문이 확정됩니다.
           </p>
@@ -115,7 +119,10 @@ export default function OrderCompletePage() {
   );
 }
 
-function resolveDepositDeadlineText(raw: string | undefined, orderNo: string | undefined) {
+function resolveDepositDeadlineText(
+  raw: string | undefined,
+  orderNo: string | undefined,
+) {
   if (raw && raw.trim().length > 0) return formatDateTime(raw);
 
   const fromOrderNo = parseOrderNoDate(orderNo);

--- a/src/pages/site/OrderLookupPage.tsx
+++ b/src/pages/site/OrderLookupPage.tsx
@@ -30,7 +30,9 @@ export default function OrderLookupPage() {
       setOrder(result);
     } catch (error) {
       setOrder(null);
-      toast.error(error instanceof Error ? error.message : '주문 조회에 실패했어요.');
+      toast.error(
+        error instanceof Error ? error.message : '주문 조회에 실패했어요.',
+      );
     } finally {
       setLoading(false);
     }
@@ -40,7 +42,9 @@ export default function OrderLookupPage() {
     <div className="mx-auto max-w-4xl px-4 py-12">
       <Reveal>
         <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h1 className="font-heading text-3xl text-slate-900">비회원 주문 조회</h1>
+          <h1 className="font-heading text-3xl text-slate-900">
+            비회원 주문 조회
+          </h1>
           <p className="mt-2 text-sm text-slate-600">
             주문 시 설정한 조회 아이디와 비밀번호로 주문 상태를 확인하세요.
           </p>

--- a/src/pages/site/OrderPage.tsx
+++ b/src/pages/site/OrderPage.tsx
@@ -198,7 +198,8 @@ const AGREEMENT_ITEMS: Array<{
       '전 물품은 사전에 명지공방(明智工房) 팀원의 1차 검수를 진행하였으며, 물품 수령 시 현장에서의 2차 검수를 통해 이상 유무를 확인할 예정입니다. 수령 이후 발생하는 제품의 흠집, 오염, 인쇄불량, 파손 등의 문제에 대해서는 환불 및 교환이 불가합니다.',
       '이러한 정책은 한정된 예산과 물품 수량, 저마진 구조 등 운영상의 제약으로 인함을 양해 부탁드립니다.',
     ],
-    question: '위 환불 및 교환 불가 정책을 충분히 인지하였으며, 이에 동의하십니까?',
+    question:
+      '위 환불 및 교환 불가 정책을 충분히 인지하였으며, 이에 동의하십니까?',
   },
   {
     key: 'cancelRisk',
@@ -222,7 +223,8 @@ function sanitizeCartItems(raw: unknown): CartItem[] {
     if (!entry || typeof entry !== 'object') return acc;
     const item = entry as Partial<CartItem>;
     if (!item.itemId || !item.projectId || !item.name) return acc;
-    if (typeof item.price !== 'number' || !Number.isFinite(item.price)) return acc;
+    if (typeof item.price !== 'number' || !Number.isFinite(item.price))
+      return acc;
     const quantity =
       typeof item.quantity === 'number' && Number.isFinite(item.quantity)
         ? Math.max(1, Math.trunc(item.quantity))
@@ -348,8 +350,10 @@ function validateBuyerStep(draft: OrderDraft): string | null {
   const isStaff = buyer.buyerType === 'STAFF';
 
   if (isBlank(buyer.name)) return '이름을 입력해주세요.';
-  if (isStudent && isBlank(buyer.departmentOrMajor)) return '소속 학과를 입력해주세요.';
-  if (isStaff && isBlank(buyer.departmentOrMajor)) return '소속 부서를 입력해주세요.';
+  if (isStudent && isBlank(buyer.departmentOrMajor))
+    return '소속 학과를 입력해주세요.';
+  if (isStaff && isBlank(buyer.departmentOrMajor))
+    return '소속 부서를 입력해주세요.';
   if (isStudent && isBlank(buyer.studentNo)) return '학번을 입력해주세요.';
   if (isBlank(buyer.phone)) return '휴대폰 번호를 입력해주세요.';
   if (isBlank(buyer.refundBank)) return '환불 은행을 입력해주세요.';
@@ -364,7 +368,8 @@ function validateFulfillmentStep(draft: OrderDraft): string | null {
   const { fulfillment } = draft;
 
   if (isBlank(fulfillment.receiverName)) return '수령자 성함을 입력해주세요.';
-  if (isBlank(fulfillment.receiverPhone)) return '수령자 휴대폰 번호를 입력해주세요.';
+  if (isBlank(fulfillment.receiverPhone))
+    return '수령자 휴대폰 번호를 입력해주세요.';
   if (fulfillment.method === 'DELIVERY') {
     if (isBlank(fulfillment.postalCode)) return '우편번호를 입력해주세요.';
     if (isBlank(fulfillment.addressLine1)) return '기본 주소를 입력해주세요.';
@@ -380,7 +385,8 @@ function validateFinalStep(draft: OrderDraft): string | null {
   const { lookup, buyer } = draft;
   if (isBlank(lookup.lookupId)) return '조회 아이디를 입력해주세요.';
   if (isBlank(lookup.password)) return '조회 비밀번호를 입력해주세요.';
-  if (isBlank(lookup.passwordConfirm)) return '조회 비밀번호 확인을 입력해주세요.';
+  if (isBlank(lookup.passwordConfirm))
+    return '조회 비밀번호 확인을 입력해주세요.';
   if (lookup.password !== lookup.passwordConfirm) {
     return '조회 비밀번호와 비밀번호 확인이 일치하지 않아요.';
   }
@@ -396,17 +402,16 @@ export default function OrderPage() {
 
   const [draft, setDraft] = useState<OrderDraft>(() => {
     const saved = loadOrderDraft();
-    const base: OrderDraft =
-      saved ?? {
-        source: 'cart',
-        items: loadCartItems(),
-        step: 0,
-        agreements: DEFAULT_AGREEMENTS,
-        buyer: DEFAULT_BUYER,
-        lookup: DEFAULT_LOOKUP,
-        payment: DEFAULT_PAYMENT,
-        fulfillment: DEFAULT_FULFILLMENT,
-      };
+    const base: OrderDraft = saved ?? {
+      source: 'cart',
+      items: loadCartItems(),
+      step: 0,
+      agreements: DEFAULT_AGREEMENTS,
+      buyer: DEFAULT_BUYER,
+      lookup: DEFAULT_LOOKUP,
+      payment: DEFAULT_PAYMENT,
+      fulfillment: DEFAULT_FULFILLMENT,
+    };
 
     if (state.source === 'direct' && Array.isArray(state.items)) {
       return {
@@ -426,11 +431,13 @@ export default function OrderPage() {
     }
     return base;
   });
-  const [lookupCheckState, setLookupCheckState] = useState<LookupCheckState>('idle');
+  const [lookupCheckState, setLookupCheckState] =
+    useState<LookupCheckState>('idle');
   const [lookupCheckMessage, setLookupCheckMessage] = useState('');
   const [lookupCheckedId, setLookupCheckedId] = useState('');
   const [showLookupPassword, setShowLookupPassword] = useState(false);
-  const [showLookupPasswordConfirm, setShowLookupPasswordConfirm] = useState(false);
+  const [showLookupPasswordConfirm, setShowLookupPasswordConfirm] =
+    useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
@@ -542,7 +549,10 @@ export default function OrderPage() {
     }));
   };
 
-  const updateBuyer = <K extends keyof BuyerForm>(key: K, value: BuyerForm[K]) => {
+  const updateBuyer = <K extends keyof BuyerForm>(
+    key: K,
+    value: BuyerForm[K],
+  ) => {
     setDraft((prev) => ({
       ...prev,
       buyer: {
@@ -552,7 +562,10 @@ export default function OrderPage() {
     }));
   };
 
-  const updateLookup = <K extends keyof LookupForm>(key: K, value: LookupForm[K]) => {
+  const updateLookup = <K extends keyof LookupForm>(
+    key: K,
+    value: LookupForm[K],
+  ) => {
     const isLookupId = key === 'lookupId';
     const nextLookupId = isLookupId ? String(value) : draft.lookup.lookupId;
     const trimmedNextLookupId = nextLookupId.trim();
@@ -615,12 +628,15 @@ export default function OrderPage() {
       if (result.available) {
         setLookupCheckState('available');
         setLookupCheckedId(lookupId);
-        setLookupCheckMessage(result.message ?? '사용 가능한 조회 아이디입니다.');
+        setLookupCheckMessage(
+          result.message ?? '사용 가능한 조회 아이디입니다.',
+        );
       } else {
         setLookupCheckState('taken');
         setLookupCheckedId('');
         setLookupCheckMessage(
-          result.message ?? '이미 사용 중인 조회 아이디예요. 다른 아이디를 입력해주세요.',
+          result.message ??
+            '이미 사용 중인 조회 아이디예요. 다른 아이디를 입력해주세요.',
         );
       }
     } catch (error) {
@@ -636,7 +652,9 @@ export default function OrderPage() {
 
   const openDeliveryPostcode = () => {
     if (!window.daum) {
-      toast.error('주소 검색 스크립트를 불러오지 못했어요. 잠시 후 다시 시도해주세요.');
+      toast.error(
+        '주소 검색 스크립트를 불러오지 못했어요. 잠시 후 다시 시도해주세요.',
+      );
       return;
     }
 
@@ -648,7 +666,10 @@ export default function OrderPage() {
     new window.daum.Postcode({
       oncomplete: (data) => {
         updateFulfillment('postalCode', data.zonecode);
-        updateFulfillment('addressLine1', data.roadAddress || data.jibunAddress || '');
+        updateFulfillment(
+          'addressLine1',
+          data.roadAddress || data.jibunAddress || '',
+        );
       },
     }).open({ left, top });
   };
@@ -661,23 +682,33 @@ export default function OrderPage() {
     }
 
     const trimmedLookupId = draft.lookup.lookupId.trim();
-    if (lookupCheckState !== 'available' || lookupCheckedId !== trimmedLookupId) {
+    if (
+      lookupCheckState !== 'available' ||
+      lookupCheckedId !== trimmedLookupId
+    ) {
       toast.error('조회 아이디 중복 확인을 완료해주세요.');
       return;
     }
 
-    const aggregatedItems = draft.items.reduce<Record<number, number>>((acc, item) => {
-      const projectItemId = Number(item.itemId);
-      if (!Number.isFinite(projectItemId)) return acc;
-      const quantity = Number.isFinite(item.quantity) ? Math.max(1, item.quantity) : 1;
-      acc[projectItemId] = (acc[projectItemId] ?? 0) + quantity;
-      return acc;
-    }, {});
+    const aggregatedItems = draft.items.reduce<Record<number, number>>(
+      (acc, item) => {
+        const projectItemId = Number(item.itemId);
+        if (!Number.isFinite(projectItemId)) return acc;
+        const quantity = Number.isFinite(item.quantity)
+          ? Math.max(1, item.quantity)
+          : 1;
+        acc[projectItemId] = (acc[projectItemId] ?? 0) + quantity;
+        return acc;
+      },
+      {},
+    );
 
-    const itemsPayload = Object.entries(aggregatedItems).map(([projectItemId, quantity]) => ({
-      projectItemId: Number(projectItemId),
-      quantity,
-    }));
+    const itemsPayload = Object.entries(aggregatedItems).map(
+      ([projectItemId, quantity]) => ({
+        projectItemId: Number(projectItemId),
+        quantity,
+      }),
+    );
 
     if (itemsPayload.length === 0) {
       toast.error('주문 상품 정보가 올바르지 않아 제출할 수 없어요.');
@@ -694,7 +725,9 @@ export default function OrderPage() {
       items: itemsPayload,
       buyer: {
         buyerType: draft.buyer.buyerType,
-        ...(draft.buyer.buyerType !== 'EXTERNAL' ? { campus: draft.buyer.campus } : {}),
+        ...(draft.buyer.buyerType !== 'EXTERNAL'
+          ? { campus: draft.buyer.campus }
+          : {}),
         name: draft.buyer.name.trim(),
         ...(draft.buyer.buyerType !== 'EXTERNAL'
           ? { departmentOrMajor: draft.buyer.departmentOrMajor.trim() }
@@ -743,7 +776,9 @@ export default function OrderPage() {
       });
     } catch (error) {
       toast.error(
-        error instanceof Error ? error.message : '주문 제출 중 오류가 발생했어요.',
+        error instanceof Error
+          ? error.message
+          : '주문 제출 중 오류가 발생했어요.',
       );
     } finally {
       setIsSubmitting(false);
@@ -754,7 +789,8 @@ export default function OrderPage() {
   const isStaff = draft.buyer.buyerType === 'STAFF';
   const isDelivery = draft.fulfillment.method === 'DELIVERY';
   const hasLookupPassword = draft.lookup.password.trim().length > 0;
-  const hasLookupPasswordConfirm = draft.lookup.passwordConfirm.trim().length > 0;
+  const hasLookupPasswordConfirm =
+    draft.lookup.passwordConfirm.trim().length > 0;
   const isLookupPasswordMatched =
     hasLookupPassword &&
     hasLookupPasswordConfirm &&
@@ -763,8 +799,8 @@ export default function OrderPage() {
     draft.buyer.campus === 'SEOUL'
       ? '서울캠퍼스'
       : draft.buyer.campus === 'YONGIN'
-      ? '자연캠퍼스'
-      : '미선택';
+        ? '자연캠퍼스'
+        : '미선택';
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-12">
@@ -798,7 +834,9 @@ export default function OrderPage() {
           <>
             {items.length === 0 ? (
               <div className="text-center">
-                <p className="text-sm font-semibold text-slate-500">주문할 상품이 없어요.</p>
+                <p className="text-sm font-semibold text-slate-500">
+                  주문할 상품이 없어요.
+                </p>
                 <Link
                   to="/projects"
                   className="mt-4 inline-flex h-11 items-center justify-center rounded-2xl bg-primary px-5 text-sm font-semibold text-white hover:opacity-95"
@@ -815,7 +853,9 @@ export default function OrderPage() {
                       className="rounded-2xl border border-slate-200 px-4 py-3"
                     >
                       <div className="flex items-center justify-between gap-3">
-                        <p className="text-sm font-semibold text-slate-900">{item.name}</p>
+                        <p className="text-sm font-semibold text-slate-900">
+                          {item.name}
+                        </p>
                         <button
                           type="button"
                           onClick={() => handleRemoveItem(item.itemId)}
@@ -825,14 +865,17 @@ export default function OrderPage() {
                         </button>
                       </div>
                       <p className="mt-1 text-sm text-slate-700">
-                        {item.quantity}개 · {formatMoney(item.price * item.quantity)}원
+                        {item.quantity}개 ·{' '}
+                        {formatMoney(item.price * item.quantity)}원
                       </p>
                     </li>
                   ))}
                 </ul>
 
                 <div className="mt-6 flex items-center justify-between rounded-2xl bg-slate-50 px-4 py-3">
-                  <p className="text-sm font-semibold text-slate-700">총 결제 예상 금액</p>
+                  <p className="text-sm font-semibold text-slate-700">
+                    총 결제 예상 금액
+                  </p>
                   <p className="text-base font-bold text-slate-900">
                     {formatMoney(totalPrice)}원
                   </p>
@@ -844,8 +887,12 @@ export default function OrderPage() {
 
         {draft.step === 1 && (
           <>
-            <h2 className="font-heading text-xl text-slate-900">구매 전 필수 동의</h2>
-            <p className="mt-1 text-sm text-slate-600">아래 항목은 모두 필수 동의입니다.</p>
+            <h2 className="font-heading text-xl text-slate-900">
+              구매 전 필수 동의
+            </h2>
+            <p className="mt-1 text-sm text-slate-600">
+              아래 항목은 모두 필수 동의입니다.
+            </p>
 
             <div className="mt-5 space-y-3">
               {AGREEMENT_ITEMS.map((agreement) => (
@@ -863,7 +910,9 @@ export default function OrderPage() {
                       className="mt-1 h-5 w-5 rounded-sm border-2 border-slate-300 text-primary focus:ring-2 focus:ring-primary/20"
                     />
                     <div>
-                      <p className="text-sm font-bold text-slate-900">{agreement.title}</p>
+                      <p className="text-sm font-bold text-slate-900">
+                        {agreement.title}
+                      </p>
                       <p className="mt-3 text-xs font-bold text-slate-800">
                         {agreement.noticeTitle}
                       </p>
@@ -894,7 +943,9 @@ export default function OrderPage() {
 
         {draft.step === 2 && (
           <>
-            <h2 className="font-heading text-xl text-slate-900">구매자 신분 및 정보 입력</h2>
+            <h2 className="font-heading text-xl text-slate-900">
+              구매자 신분 및 정보 입력
+            </h2>
             <p className="mt-1 text-sm text-slate-600">
               신분에 따라 필요한 입력 항목이 달라집니다.
             </p>
@@ -904,38 +955,44 @@ export default function OrderPage() {
                 Buyer Type
               </p>
               <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-3">
-              {[
-                {
-                  value: 'STUDENT',
-                  label: '재학생',
-                  description: '학과/학번 정보까지 입력',
-                },
-                {
-                  value: 'STAFF',
-                  label: '교직원',
-                  description: '소속 부서 정보를 입력',
-                },
-                {
-                  value: 'EXTERNAL',
-                  label: '외부인',
-                  description: '기본 인적 사항 입력',
-                },
-              ].map((item) => (
-                <button
-                  key={item.value}
-                  type="button"
-                  onClick={() => updateBuyer('buyerType', item.value as BuyerType)}
-                  className={[
-                    'rounded-2xl border-2 bg-white px-4 py-3 text-left shadow-sm transition',
-                    draft.buyer.buyerType === item.value
-                      ? 'border-primary/40 ring-2 ring-primary/15'
-                      : 'border-slate-200 hover:border-slate-300',
-                  ].join(' ')}
-                >
-                  <p className="text-sm font-bold text-slate-900">{item.label}</p>
-                  <p className="mt-1 text-xs text-slate-500">{item.description}</p>
-                </button>
-              ))}
+                {[
+                  {
+                    value: 'STUDENT',
+                    label: '재학생',
+                    description: '학과/학번 정보까지 입력',
+                  },
+                  {
+                    value: 'STAFF',
+                    label: '교직원',
+                    description: '소속 부서 정보를 입력',
+                  },
+                  {
+                    value: 'EXTERNAL',
+                    label: '외부인',
+                    description: '기본 인적 사항 입력',
+                  },
+                ].map((item) => (
+                  <button
+                    key={item.value}
+                    type="button"
+                    onClick={() =>
+                      updateBuyer('buyerType', item.value as BuyerType)
+                    }
+                    className={[
+                      'rounded-2xl border-2 bg-white px-4 py-3 text-left shadow-sm transition',
+                      draft.buyer.buyerType === item.value
+                        ? 'border-primary/40 ring-2 ring-primary/15'
+                        : 'border-slate-200 hover:border-slate-300',
+                    ].join(' ')}
+                  >
+                    <p className="text-sm font-bold text-slate-900">
+                      {item.label}
+                    </p>
+                    <p className="mt-1 text-xs text-slate-500">
+                      {item.description}
+                    </p>
+                  </button>
+                ))}
               </div>
             </div>
 
@@ -955,7 +1012,10 @@ export default function OrderPage() {
                     <select
                       value={draft.buyer.campus}
                       onChange={(event) =>
-                        updateBuyer('campus', event.target.value as BuyerForm['campus'])
+                        updateBuyer(
+                          'campus',
+                          event.target.value as BuyerForm['campus'],
+                        )
                       }
                       className={SELECT_CLASS}
                     >
@@ -998,14 +1058,17 @@ export default function OrderPage() {
 
               {(isStudent || isStaff) && (
                 <label className="text-sm font-semibold text-slate-700">
-                  {isStudent ? '소속 학과' : '소속 부서'} <span className="text-rose-500">*</span>
+                  {isStudent ? '소속 학과' : '소속 부서'}{' '}
+                  <span className="text-rose-500">*</span>
                   <input
                     value={draft.buyer.departmentOrMajor}
                     onChange={(event) =>
                       updateBuyer('departmentOrMajor', event.target.value)
                     }
                     className={INPUT_CLASS}
-                    placeholder={isStudent ? '예) 컴퓨터공학과' : '예) 학생지원팀'}
+                    placeholder={
+                      isStudent ? '예) 컴퓨터공학과' : '예) 학생지원팀'
+                    }
                   />
                 </label>
               )}
@@ -1015,7 +1078,9 @@ export default function OrderPage() {
                   학번 <span className="text-rose-500">*</span>
                   <input
                     value={draft.buyer.studentNo}
-                    onChange={(event) => updateBuyer('studentNo', event.target.value)}
+                    onChange={(event) =>
+                      updateBuyer('studentNo', event.target.value)
+                    }
                     className={INPUT_CLASS}
                     placeholder="예) 60123456"
                   />
@@ -1036,7 +1101,9 @@ export default function OrderPage() {
                 환불 은행 <span className="text-rose-500">*</span>
                 <input
                   value={draft.buyer.refundBank}
-                  onChange={(event) => updateBuyer('refundBank', event.target.value)}
+                  onChange={(event) =>
+                    updateBuyer('refundBank', event.target.value)
+                  }
                   className={INPUT_CLASS}
                   placeholder="예) 국민은행"
                 />
@@ -1046,7 +1113,9 @@ export default function OrderPage() {
                 환불 계좌 <span className="text-rose-500">*</span>
                 <input
                   value={draft.buyer.refundAccount}
-                  onChange={(event) => updateBuyer('refundAccount', event.target.value)}
+                  onChange={(event) =>
+                    updateBuyer('refundAccount', event.target.value)
+                  }
                   className={INPUT_CLASS}
                   placeholder="예) 123456-78-901234"
                 />
@@ -1056,7 +1125,9 @@ export default function OrderPage() {
                 알게 된 경로 <span className="text-rose-500">*</span>
                 <input
                   value={draft.buyer.referralSource}
-                  onChange={(event) => updateBuyer('referralSource', event.target.value)}
+                  onChange={(event) =>
+                    updateBuyer('referralSource', event.target.value)
+                  }
                   className={INPUT_CLASS}
                   placeholder="예) instagram"
                 />
@@ -1066,7 +1137,9 @@ export default function OrderPage() {
                 입금자명 <span className="text-rose-500">*</span>
                 <input
                   value={draft.payment.depositorName}
-                  onChange={(event) => updatePayment('depositorName', event.target.value)}
+                  onChange={(event) =>
+                    updatePayment('depositorName', event.target.value)
+                  }
                   className={INPUT_CLASS}
                   placeholder="예) 홍길동"
                 />
@@ -1077,8 +1150,12 @@ export default function OrderPage() {
 
         {draft.step === 3 && (
           <>
-            <h2 className="font-heading text-xl text-slate-900">수령 방식 선택</h2>
-            <p className="mt-1 text-sm text-slate-600">현장 수령 또는 택배 배송을 선택해주세요.</p>
+            <h2 className="font-heading text-xl text-slate-900">
+              수령 방식 선택
+            </h2>
+            <p className="mt-1 text-sm text-slate-600">
+              현장 수령 또는 택배 배송을 선택해주세요.
+            </p>
 
             <div className="mt-5 grid grid-cols-1 gap-2 sm:grid-cols-2">
               {[
@@ -1106,8 +1183,12 @@ export default function OrderPage() {
                       : 'border-slate-200 hover:border-slate-300',
                   ].join(' ')}
                 >
-                  <p className="text-sm font-bold text-slate-900">{item.label}</p>
-                  <p className="mt-1 text-xs text-slate-500">{item.description}</p>
+                  <p className="text-sm font-bold text-slate-900">
+                    {item.label}
+                  </p>
+                  <p className="mt-1 text-xs text-slate-500">
+                    {item.description}
+                  </p>
                 </button>
               ))}
             </div>
@@ -1117,7 +1198,9 @@ export default function OrderPage() {
                 수령자 성함 <span className="text-rose-500">*</span>
                 <input
                   value={draft.fulfillment.receiverName}
-                  onChange={(event) => updateFulfillment('receiverName', event.target.value)}
+                  onChange={(event) =>
+                    updateFulfillment('receiverName', event.target.value)
+                  }
                   className={INPUT_CLASS}
                   placeholder="수령자 이름"
                 />
@@ -1126,7 +1209,9 @@ export default function OrderPage() {
                 수령자 휴대폰 번호 <span className="text-rose-500">*</span>
                 <input
                   value={draft.fulfillment.receiverPhone}
-                  onChange={(event) => updateFulfillment('receiverPhone', event.target.value)}
+                  onChange={(event) =>
+                    updateFulfillment('receiverPhone', event.target.value)
+                  }
                   className={INPUT_CLASS}
                   placeholder="예) 010-1234-5678"
                 />
@@ -1135,7 +1220,9 @@ export default function OrderPage() {
 
             {isDelivery && (
               <div className="mt-6 rounded-2xl border border-slate-200 bg-slate-50 p-4">
-                <h3 className="text-sm font-bold text-slate-900">배송지 정보</h3>
+                <h3 className="text-sm font-bold text-slate-900">
+                  배송지 정보
+                </h3>
                 <p className="mt-1 text-xs text-slate-600">
                   주소 검색은 카카오맵 API 연동 단계에서 연결할 예정입니다.
                 </p>
@@ -1215,23 +1302,30 @@ export default function OrderPage() {
 
         {draft.step === 4 && (
           <>
-            <h2 className="font-heading text-xl text-slate-900">최종 확인 및 제출</h2>
+            <h2 className="font-heading text-xl text-slate-900">
+              최종 확인 및 제출
+            </h2>
             <p className="mt-1 text-sm text-slate-600">
               입력한 정보를 최종 확인한 뒤 구매 제출을 진행해주세요.
             </p>
 
             <div className="mt-6 space-y-4">
               <section className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
-                <h3 className="text-sm font-bold text-slate-900">주문 조회 계정 설정</h3>
+                <h3 className="text-sm font-bold text-slate-900">
+                  주문 조회 계정 설정
+                </h3>
                 <p className="mt-1 text-xs leading-relaxed text-slate-600">
-                  주문 이후 상태 조회(입금 확인/배송 진행)를 위해 조회 아이디와 비밀번호를 설정해주세요.
+                  주문 이후 상태 조회(입금 확인/배송 진행)를 위해 조회 아이디와
+                  비밀번호를 설정해주세요.
                 </p>
                 <div className="mt-3 grid grid-cols-1 gap-4 sm:grid-cols-[1fr_auto]">
                   <label className="text-sm font-semibold text-slate-700">
                     조회 아이디 <span className="text-rose-500">*</span>
                     <input
                       value={draft.lookup.lookupId}
-                      onChange={(event) => updateLookup('lookupId', event.target.value)}
+                      onChange={(event) =>
+                        updateLookup('lookupId', event.target.value)
+                      }
                       className={INPUT_CLASS}
                       placeholder="예) guest-mju-001"
                     />
@@ -1243,7 +1337,9 @@ export default function OrderPage() {
                       disabled={lookupCheckState === 'checking'}
                       className="inline-flex h-12 items-center justify-center rounded-2xl border border-slate-200 px-4 text-sm font-semibold text-slate-700 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-60"
                     >
-                      {lookupCheckState === 'checking' ? '확인 중...' : '아이디 확인'}
+                      {lookupCheckState === 'checking'
+                        ? '확인 중...'
+                        : '아이디 확인'}
                     </button>
                   </div>
                 </div>
@@ -1254,9 +1350,10 @@ export default function OrderPage() {
                       'mt-2 rounded-xl px-3 py-2 text-xs font-semibold',
                       lookupCheckState === 'available'
                         ? 'border border-emerald-200 bg-emerald-50 text-emerald-700'
-                        : lookupCheckState === 'taken' || lookupCheckState === 'error'
-                        ? 'border border-rose-200 bg-rose-50 text-rose-700'
-                        : 'border border-slate-200 bg-white text-slate-600',
+                        : lookupCheckState === 'taken' ||
+                            lookupCheckState === 'error'
+                          ? 'border border-rose-200 bg-rose-50 text-rose-700'
+                          : 'border border-slate-200 bg-white text-slate-600',
                     ].join(' ')}
                   >
                     {lookupCheckMessage}
@@ -1270,7 +1367,9 @@ export default function OrderPage() {
                       <input
                         type={showLookupPassword ? 'text' : 'password'}
                         value={draft.lookup.password}
-                        onChange={(event) => updateLookup('password', event.target.value)}
+                        onChange={(event) =>
+                          updateLookup('password', event.target.value)
+                        }
                         className={INPUT_CLASS}
                         placeholder="비밀번호 입력"
                       />
@@ -1302,7 +1401,9 @@ export default function OrderPage() {
                       />
                       <button
                         type="button"
-                        onClick={() => setShowLookupPasswordConfirm((prev) => !prev)}
+                        onClick={() =>
+                          setShowLookupPasswordConfirm((prev) => !prev)
+                        }
                         className="absolute right-3 top-1/2 -translate-y-1/2 rounded-md p-1 text-slate-500 hover:bg-slate-100 hover:text-slate-700"
                         aria-label="조회 비밀번호 확인 표시 전환"
                       >
@@ -1317,7 +1418,9 @@ export default function OrderPage() {
                       <p
                         className={[
                           'mt-1 text-xs font-semibold',
-                          isLookupPasswordMatched ? 'text-emerald-600' : 'text-rose-600',
+                          isLookupPasswordMatched
+                            ? 'text-emerald-600'
+                            : 'text-rose-600',
                         ].join(' ')}
                       >
                         {isLookupPasswordMatched
@@ -1331,7 +1434,9 @@ export default function OrderPage() {
                     <input
                       type="email"
                       value={draft.buyer.email}
-                      onChange={(event) => updateBuyer('email', event.target.value)}
+                      onChange={(event) =>
+                        updateBuyer('email', event.target.value)
+                      }
                       className={INPUT_CLASS}
                       placeholder="주문 조회 링크를 받을 이메일"
                     />
@@ -1347,7 +1452,9 @@ export default function OrderPage() {
                       key={`${item.projectId}-${item.itemId}`}
                       className="flex items-center justify-between rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
                     >
-                      <span className="text-slate-700">{item.name} x {item.quantity}</span>
+                      <span className="text-slate-700">
+                        {item.name} x {item.quantity}
+                      </span>
                       <span className="font-semibold text-slate-900">
                         {formatMoney(item.price * item.quantity)}원
                       </span>
@@ -1360,7 +1467,9 @@ export default function OrderPage() {
               </section>
 
               <section className="rounded-3xl border border-slate-200 bg-white p-5 text-sm text-slate-700">
-                <h3 className="text-sm font-bold text-slate-900">구매자 정보</h3>
+                <h3 className="text-sm font-bold text-slate-900">
+                  구매자 정보
+                </h3>
                 <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
                   <div className="rounded-xl bg-slate-50 px-3 py-2">
                     구매자 구분: {BUYER_TYPE_LABELS[draft.buyer.buyerType]}
@@ -1370,32 +1479,56 @@ export default function OrderPage() {
                       캠퍼스: {CAMPUS_LABELS[draft.buyer.campus]}
                     </div>
                   )}
-                  <div className="rounded-xl bg-slate-50 px-3 py-2">이름: {draft.buyer.name || '-'}</div>
+                  <div className="rounded-xl bg-slate-50 px-3 py-2">
+                    이름: {draft.buyer.name || '-'}
+                  </div>
                   {(isStudent || isStaff) && (
                     <div className="rounded-xl bg-slate-50 px-3 py-2">
-                      {isStudent ? '소속 학과' : '소속 부서'}: {draft.buyer.departmentOrMajor || '-'}
+                      {isStudent ? '소속 학과' : '소속 부서'}:{' '}
+                      {draft.buyer.departmentOrMajor || '-'}
                     </div>
                   )}
                   {isStudent && (
-                    <div className="rounded-xl bg-slate-50 px-3 py-2">학번: {draft.buyer.studentNo || '-'}</div>
+                    <div className="rounded-xl bg-slate-50 px-3 py-2">
+                      학번: {draft.buyer.studentNo || '-'}
+                    </div>
                   )}
-                  <div className="rounded-xl bg-slate-50 px-3 py-2">휴대폰 번호: {draft.buyer.phone || '-'}</div>
-                  <div className="rounded-xl bg-slate-50 px-3 py-2">환불 은행: {draft.buyer.refundBank || '-'}</div>
-                  <div className="rounded-xl bg-slate-50 px-3 py-2">환불 계좌: {draft.buyer.refundAccount || '-'}</div>
-                  <div className="rounded-xl bg-slate-50 px-3 py-2">알게 된 경로: {draft.buyer.referralSource || '-'}</div>
-                  <div className="rounded-xl bg-slate-50 px-3 py-2">이메일: {draft.buyer.email || '-'}</div>
+                  <div className="rounded-xl bg-slate-50 px-3 py-2">
+                    휴대폰 번호: {draft.buyer.phone || '-'}
+                  </div>
+                  <div className="rounded-xl bg-slate-50 px-3 py-2">
+                    환불 은행: {draft.buyer.refundBank || '-'}
+                  </div>
+                  <div className="rounded-xl bg-slate-50 px-3 py-2">
+                    환불 계좌: {draft.buyer.refundAccount || '-'}
+                  </div>
+                  <div className="rounded-xl bg-slate-50 px-3 py-2">
+                    알게 된 경로: {draft.buyer.referralSource || '-'}
+                  </div>
+                  <div className="rounded-xl bg-slate-50 px-3 py-2">
+                    이메일: {draft.buyer.email || '-'}
+                  </div>
                 </div>
               </section>
 
               <section className="rounded-3xl border border-slate-200 bg-white p-5 text-sm text-slate-700">
-                <h3 className="text-sm font-bold text-slate-900">조회 계정 정보</h3>
+                <h3 className="text-sm font-bold text-slate-900">
+                  조회 계정 정보
+                </h3>
                 <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
-                  <div className="rounded-xl bg-slate-50 px-3 py-2">조회 아이디: {draft.lookup.lookupId || '-'}</div>
-                  <div className="rounded-xl bg-slate-50 px-3 py-2">조회 비밀번호: {draft.lookup.password ? '입력 완료' : '-'}</div>
                   <div className="rounded-xl bg-slate-50 px-3 py-2">
-                    아이디 확인 상태: {lookupCheckState === 'available' ? '확인 완료' : '미확인'}
+                    조회 아이디: {draft.lookup.lookupId || '-'}
                   </div>
-                  <div className="rounded-xl bg-slate-50 px-3 py-2">이메일: {draft.buyer.email || '-'}</div>
+                  <div className="rounded-xl bg-slate-50 px-3 py-2">
+                    조회 비밀번호: {draft.lookup.password ? '입력 완료' : '-'}
+                  </div>
+                  <div className="rounded-xl bg-slate-50 px-3 py-2">
+                    아이디 확인 상태:{' '}
+                    {lookupCheckState === 'available' ? '확인 완료' : '미확인'}
+                  </div>
+                  <div className="rounded-xl bg-slate-50 px-3 py-2">
+                    이메일: {draft.buyer.email || '-'}
+                  </div>
                 </div>
               </section>
 
@@ -1410,19 +1543,33 @@ export default function OrderPage() {
                 <h3 className="text-sm font-bold text-slate-900">수령 정보</h3>
                 <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
                   <div className="rounded-xl bg-slate-50 px-3 py-2">
-                    수령 방식: {FULFILLMENT_METHOD_LABELS[draft.fulfillment.method]}
+                    수령 방식:{' '}
+                    {FULFILLMENT_METHOD_LABELS[draft.fulfillment.method]}
                   </div>
-                  <div className="rounded-xl bg-slate-50 px-3 py-2">수령자 성함: {draft.fulfillment.receiverName || '-'}</div>
-                  <div className="rounded-xl bg-slate-50 px-3 py-2">수령자 휴대폰 번호: {draft.fulfillment.receiverPhone || '-'}</div>
                   <div className="rounded-xl bg-slate-50 px-3 py-2">
-                    정보 정확성 확인: {draft.fulfillment.infoConfirmed ? '확인 완료' : '미확인'}
+                    수령자 성함: {draft.fulfillment.receiverName || '-'}
+                  </div>
+                  <div className="rounded-xl bg-slate-50 px-3 py-2">
+                    수령자 휴대폰 번호: {draft.fulfillment.receiverPhone || '-'}
+                  </div>
+                  <div className="rounded-xl bg-slate-50 px-3 py-2">
+                    정보 정확성 확인:{' '}
+                    {draft.fulfillment.infoConfirmed ? '확인 완료' : '미확인'}
                   </div>
                   {isDelivery && (
                     <>
-                      <div className="rounded-xl bg-slate-50 px-3 py-2">우편번호: {draft.fulfillment.postalCode || '-'}</div>
-                      <div className="rounded-xl bg-slate-50 px-3 py-2">기본 주소: {draft.fulfillment.addressLine1 || '-'}</div>
-                      <div className="rounded-xl bg-slate-50 px-3 py-2 sm:col-span-2">상세 주소: {draft.fulfillment.addressLine2 || '-'}</div>
-                      <div className="rounded-xl bg-slate-50 px-3 py-2 sm:col-span-2">배송 메모: {draft.fulfillment.deliveryMemo || '-'}</div>
+                      <div className="rounded-xl bg-slate-50 px-3 py-2">
+                        우편번호: {draft.fulfillment.postalCode || '-'}
+                      </div>
+                      <div className="rounded-xl bg-slate-50 px-3 py-2">
+                        기본 주소: {draft.fulfillment.addressLine1 || '-'}
+                      </div>
+                      <div className="rounded-xl bg-slate-50 px-3 py-2 sm:col-span-2">
+                        상세 주소: {draft.fulfillment.addressLine2 || '-'}
+                      </div>
+                      <div className="rounded-xl bg-slate-50 px-3 py-2 sm:col-span-2">
+                        배송 메모: {draft.fulfillment.deliveryMemo || '-'}
+                      </div>
                     </>
                   )}
                 </div>

--- a/src/pages/site/OrderViewPage.tsx
+++ b/src/pages/site/OrderViewPage.tsx
@@ -9,15 +9,16 @@ export default function OrderViewPage() {
   const toast = useToast();
   const [searchParams] = useSearchParams();
   const token = searchParams.get('token')?.trim() ?? '';
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [order, setOrder] = useState<OrderDetailResponse | null>(null);
 
   useEffect(() => {
-    if (!token) return;
+    if (!token) {
+      setLoading(false);
+      return;
+    }
 
     let active = true;
-    setLoading(true);
-    setOrder(null);
 
     ordersApi
       .viewOrder(token)
@@ -27,7 +28,9 @@ export default function OrderViewPage() {
       })
       .catch((error) => {
         if (!active) return;
-        toast.error(error instanceof Error ? error.message : '주문 조회에 실패했어요.');
+        toast.error(
+          error instanceof Error ? error.message : '주문 조회에 실패했어요.',
+        );
       })
       .finally(() => {
         if (!active) return;
@@ -44,7 +47,9 @@ export default function OrderViewPage() {
       <div className="mx-auto max-w-3xl px-4 py-12">
         <Reveal>
           <section className="rounded-3xl border border-rose-200 bg-white p-6 shadow-sm">
-            <h1 className="font-heading text-2xl text-slate-900">잘못된 접근이에요</h1>
+            <h1 className="font-heading text-2xl text-slate-900">
+              잘못된 접근이에요
+            </h1>
             <p className="mt-2 text-sm text-slate-600">
               조회 토큰이 없어서 주문 정보를 확인할 수 없어요.
             </p>
@@ -68,7 +73,11 @@ export default function OrderViewPage() {
           <p className="mt-2 text-sm text-slate-600">
             이메일 링크를 통해 주문 정보를 불러왔어요.
           </p>
-          {loading && <p className="mt-3 text-sm font-semibold text-primary">조회 중...</p>}
+          {loading && (
+            <p className="mt-3 text-sm font-semibold text-primary">
+              조회 중...
+            </p>
+          )}
         </section>
       </Reveal>
 

--- a/src/pages/site/ProjectItemDetailPage.tsx
+++ b/src/pages/site/ProjectItemDetailPage.tsx
@@ -541,6 +541,7 @@ export default function ProjectItemDetailPage() {
     setShowCartNotice(true);
     toast.success('장바구니에 상품을 담았어요.');
   };
+
   const handleBuyNow = () => {
     if (isSoldOut) {
       toast.error('재고가 소진되어 구매할 수 없어요.');
@@ -597,7 +598,6 @@ export default function ProjectItemDetailPage() {
               onOpen={setActiveImage}
               fallbackLabel="대표 이미지가 없어요"
             />
-
             <PurchaseCard
               item={item}
               saleTypeLabel={saleTypeLabel}

--- a/src/utils/cart.ts
+++ b/src/utils/cart.ts
@@ -30,7 +30,8 @@ function parseStored(raw: string | null): CartItem[] {
       if (!entry || typeof entry !== 'object') return acc;
       const item = entry as Partial<CartItem>;
       if (!item.itemId || !item.projectId || !item.name) return acc;
-      if (typeof item.price !== 'number' || !Number.isFinite(item.price)) return acc;
+      if (typeof item.price !== 'number' || !Number.isFinite(item.price))
+        return acc;
 
       acc.push({
         itemId: String(item.itemId),


### PR DESCRIPTION
#66 

**요약**
- 주문/주문조회 라우팅을 `SiteLayout` 안으로 정리
- 주문 페이지에서 플로팅 SNS 숨김 조건 보완
- 주문 조회 페이지 및 상품 상세 페이지 오류 수정

**변경 사항**
- `App.tsx`: `/orders/lookup`, `/orders/view` 라우팅 정리, SNS 숨김 조건 수정
- `OrderViewPage.tsx`: 초기 로딩 처리 및 effect 내 setState 오류 해결
- `ProjectItemDetailPage.tsx`: `pushToCart` 중복 선언 제거

**확인 방법**
1. `/orders/lookup`, `/orders/view` 진입 시 헤더/레이아웃 정상 표시 확인
2. `/order`, `/order/complete`에서 플로팅 SNS 숨김 확인
3. 상품 상세에서 장바구니 담기/구매하기 정상 동작 확인