### PR TITLE
Fix: Vercel API rewrite base URL 수정

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "rewrites": [
     {
       "source": "/api/:path*",
-      "destination": "http://54.180.142.40/api/:path*"
+      "destination": "https://api.mju-craft.shop/api/:path*"
     },
     {
       "source": "/(.*)",


### PR DESCRIPTION
## 요약
- Vercel `rewrites`에서 API base URL을 올바른 도메인으로 수정

## 변경 사항
- `vercel.json`의 `/api/:path*` 대상 URL 수정

## 체크
- [ ] 배포 환경에서 API 요청 정상 동작 확인