### PR TITLE
fix: 공지 상세/목록 이미지 렌더링을 presigned URL로 전환

### DIFF
--- a/src/api/adminNotices.ts
+++ b/src/api/adminNotices.ts
@@ -7,6 +7,7 @@ export type AdminNoticeResponse = {
   title: string;
   content: string;
   imageKeys?: string[] | null;
+  imageUrls?: string[] | null;
   createdAt?: string | number[] | null;
   updatedAt?: string | number[] | null;
 };

--- a/src/api/notices.ts
+++ b/src/api/notices.ts
@@ -7,6 +7,7 @@ export type NoticeResponse = {
   title: string;
   content?: string | null;
   imageKeys?: string[] | null;
+  imageUrls?: string[] | null;
   createdAt?: string | number[] | null;
   updatedAt?: string | number[] | null;
 };

--- a/src/pages/admin/AdminNoticeEditorPage.tsx
+++ b/src/pages/admin/AdminNoticeEditorPage.tsx
@@ -55,21 +55,30 @@ function createEmpty(): NoticeForm {
 }
 
 function toForm(notice: AdminNoticeResponse): NoticeForm {
+  const keys = notice.imageKeys ?? [];
+  const urls = notice.imageUrls ?? [];
+  const length = Math.max(keys.length, urls.length);
+
   return {
     id: String(notice.id),
     title: notice.title ?? '',
     content: notice.content ?? '',
-    images: (notice.imageKeys ?? []).map((key, idx) => ({
-      id: `server-${key}-${idx}`,
-      key,
-    })),
+    images: Array.from({ length }).map((_, idx) => {
+      const key = keys[idx];
+      const previewUrl = urls[idx];
+      return {
+        id: `server-${key ?? previewUrl ?? idx}-${idx}`,
+        key,
+        previewUrl,
+      };
+    }),
     isDirty: false,
   };
 }
 
 const PUBLIC_ASSET_BASE = API_BASE.replace(/\/api\/?$/, '');
 
-function resolveNoticeImageUrl(key: string) {
+function resolveLegacyImageUrl(key: string) {
   if (/^https?:\/\//i.test(key)) return key;
   const normalized = key.replace(/^\/+/, '');
   if (!normalized) return '';
@@ -106,7 +115,7 @@ function SortableImageCard({
   } as const;
 
   const src =
-    item.previewUrl || (item.key ? resolveNoticeImageUrl(item.key) : '');
+    item.previewUrl || (item.key ? resolveLegacyImageUrl(item.key) : '');
 
   return (
     <div

--- a/src/pages/admin/AdminNoticesListPage.tsx
+++ b/src/pages/admin/AdminNoticesListPage.tsx
@@ -30,6 +30,12 @@ function toDateValue(value?: unknown) {
   return null;
 }
 
+function getImageCount(notice: AdminNoticeResponse) {
+  const urlCount = notice.imageUrls?.length ?? 0;
+  if (urlCount > 0) return urlCount;
+  return notice.imageKeys?.length ?? 0;
+}
+
 export default function AdminNoticesListPage() {
   const navigate = useNavigate();
   const confirm = useConfirm();
@@ -66,7 +72,7 @@ export default function AdminNoticesListPage() {
     const normalized = query.trim().toLowerCase();
 
     const next = notices.filter((notice) => {
-      const hasImages = (notice.imageKeys?.length ?? 0) > 0;
+      const hasImages = getImageCount(notice) > 0;
       if (imageFilter === 'with' && !hasImages) return false;
       if (imageFilter === 'without' && hasImages) return false;
 
@@ -222,7 +228,7 @@ export default function AdminNoticesListPage() {
                     </p>
                   </div>
                   <span className="rounded-full bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-500">
-                    이미지 {notice.imageKeys?.length ?? 0}개
+                    이미지 {getImageCount(notice)}개
                   </span>
                 </div>
                 <p className="mt-3 text-sm text-slate-600">

--- a/src/pages/site/NoticeDetailPage.tsx
+++ b/src/pages/site/NoticeDetailPage.tsx
@@ -5,18 +5,26 @@ import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 import Reveal from '../../components/Reveal';
 import { noticesApi, type NoticeResponse } from '../../api/notices';
-import { formatYmd, parseDateLike } from '../../utils/date';
 import { API_BASE } from '../../api/client';
+import { formatYmd, parseDateLike } from '../../utils/date';
 
 const PUBLIC_ASSET_BASE = API_BASE.replace(/\/api\/?$/, '');
 
-function resolveNoticeImageUrl(key: string) {
+function resolveLegacyImageUrl(key: string) {
   if (/^https?:\/\//i.test(key)) return key;
   const normalized = key.replace(/^\/+/, '');
   if (!normalized) return '';
   return PUBLIC_ASSET_BASE
     ? `${PUBLIC_ASSET_BASE}/${normalized}`
     : `/${normalized}`;
+}
+
+function getNoticeImages(notice: NoticeResponse): string[] {
+  const urls = notice.imageUrls?.filter(Boolean) ?? [];
+  if (urls.length > 0) return urls;
+  return (notice.imageKeys ?? [])
+    .map(resolveLegacyImageUrl)
+    .filter(Boolean);
 }
 
 export default function NoticeDetailPage() {
@@ -96,9 +104,7 @@ export default function NoticeDetailPage() {
     );
   }
 
-  const images = (notice.imageKeys ?? [])
-    .map(resolveNoticeImageUrl)
-    .filter(Boolean);
+  const images = getNoticeImages(notice);
 
   return (
     <div className="mx-auto max-w-6xl px-4 py-12">


### PR DESCRIPTION
## 요약
- 공지사항 이미지 조회 방식을 imageKeys 직접 변환에서 imageUrls(presigned URL) 우선 사용으로 변경했습니다.
---

## 작업내용
- 공지 API 응답 타입에 imageUrls 필드 추가
- 클라이언트 공지 목록/상세에서 imageUrls 우선 렌더링 적용
- 관리자 공지 목록/상세/수정 화면도 imageUrls 기준으로 조회 및 표시
- 레거시 데이터 호환을 위해 imageUrls가 없을 때 imageKeys fallback 유지