### PR TITLE
Fix: 브라우저 타이틀 한글 적용

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/mjucraftLogo_Blue_Round.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>MJU-CRAFT</title>
+    <title>명지공방</title>
     <script src="https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
   </head>
   <body>


### PR DESCRIPTION
#77 

## 개요
브라우저 탭/검색 결과에 표시되는 사이트 타이틀을 한글로 변경

## 변경 사항
- `index.html`의 `<title>` 문구 수정

## 확인 사항
- 브라우저 탭에서 한글 타이틀 정상 표시 확인