### PR TITLE
Fix: 네비게이션 Collections -> Projects로 변경

### DIFF
--- a/src/components/HeaderDesktop.tsx
+++ b/src/components/HeaderDesktop.tsx
@@ -52,7 +52,7 @@ export default function HeaderDesktop() {
           aria-expanded={isProjectsOpen}
           aria-haspopup="menu"
         >
-          COLLECTIONS <span className="ml-1 text-slate-400">▾</span>
+          PROJECTS <span className="ml-1 text-slate-400">▾</span>
         </button>
 
         {isProjectsOpen && (

--- a/src/components/HeaderMobile.tsx
+++ b/src/components/HeaderMobile.tsx
@@ -167,7 +167,7 @@ export default function HeaderMobile() {
                 isActive.projects ? menuActive : menuIdle
               }`}
             >
-              COLLECTIONS
+              PROJECTS
               <span
                 className={[
                   'text-slate-400 transition-transform',


### PR DESCRIPTION
## 개요
네비게이션 메뉴 라벨을  `Collections`에서 `Projects`로 변경

## 변경 사항
- 데스크탑 네비게이션(`HeaderDesktop`) 메뉴명 변경
- 모바일 네비게이션(`HeaderMobile`) 메뉴명 변경

## 영향 범위
- UI 텍스트만 변경
- 라우팅 경로(`/projects`) 및 기능 동작 변경 없음

## 확인 사항
- 데스크탑/모바일 모두 `Projects`로 표시되는지 확인
