### PR TITLE
Fix: Footer 레이아웃 간격 조정 및 Feedback 페이지 타이틀 한글화

### DIFF
--- a/src/components/SiteLayout.tsx
+++ b/src/components/SiteLayout.tsx
@@ -163,9 +163,9 @@ export default function SiteLayout() {
         <Outlet />
       </main>
 
-      <footer className="mt-20 border-t border-slate-200 bg-white">
+      <footer className="mt-100 border-t border-slate-200 bg-white">
         <div className="mx-auto max-w-6xl px-4 py-10 text-sm text-slate-600">
-          <div className="flex flex-col gap-8 md:flex-row md:items-start md:justify-between">
+          <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
             <div>
               <div className="font-heading text-lg text-primary">
                 명지공방 MJU Craft Studio
@@ -177,7 +177,7 @@ export default function SiteLayout() {
               </p>
             </div>
 
-            <div className="grid grid-cols-2 gap-6 text-xs md:grid-cols-3">
+            <div className="grid grid-cols-2 gap-6 text-xs md:grid-cols-4 md:gap-8">
               <div>
                 <h2 className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
                   Studio
@@ -268,7 +268,7 @@ export default function SiteLayout() {
             </div>
           </div>
 
-          <div className="mt-8 flex flex-col items-start justify-between gap-2 border-t border-slate-100 pt-4 text-[11px] text-slate-400 md:flex-row md:items-center">
+          <div className="mt-10 flex flex-col items-start justify-between gap-2 border-t border-slate-100 pt-8 text-[11px] text-slate-400 md:flex-row md:items-center">
             <p>
               © {new Date().getFullYear()} MJU Craft Studio. All rights
               reserved.

--- a/src/pages/site/FeedbackPage.tsx
+++ b/src/pages/site/FeedbackPage.tsx
@@ -144,7 +144,7 @@ export default function FeedbackPage() {
     <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 sm:py-12">
       <Reveal>
         <h1 className="font-heading text-2xl text-primary sm:text-3xl">
-          FEEDBACK
+          피드백
         </h1>
         <p className="mt-2 text-sm text-slate-600 sm:text-base">
           더 나은 서비스를 위해 피드백을 제출해주세요!


### PR DESCRIPTION
## 개요
Footer 레이아웃의 간격을 조정하고, Feedback 페이지 타이틀 표기를 한글로 변경

## 변경 사항
- `src/components/SiteLayout.tsx`
  - Footer 상단/내부 간격 조정
  - 구분선 주변 여백 조정으로 레이아웃 균형 개선
- `src/pages/site/FeedbackPage.tsx`
  - 페이지 타이틀 `FEEDBACK` -> `피드백` 변경

## 영향 범위
- 스타일 및 텍스트 변경
- 라우팅/기능 로직 변경 없음

## 확인 사항
- 모든 페이지에서 Footer 상단 회색 영역/간격이 의도대로 보이는지 확인
- Feedback 페이지 진입 시 타이틀이 `피드백`으로 표시되는지 확인