### PR TITLE
<Feat> 관리자 피드백·모집폼 삭제 API 연동 및 에러 토스트 개선

### DIFF
--- a/src/api/adminFeedback.ts
+++ b/src/api/adminFeedback.ts
@@ -19,17 +19,23 @@ export type AdminFeedbackUpdateRequest = {
 
 export const adminFeedbackApi = {
   list() {
-    return api<AdminFeedbackResponse[]>(
-      withApiBase('/admin/feedback'),
-    ).then((res) => {
-      return Array.isArray(res) ? res : [];
-    });
+    return api<AdminFeedbackResponse[]>(withApiBase('/admin/feedback')).then(
+      (res) => {
+        return Array.isArray(res) ? res : [];
+      },
+    );
   },
 
   update(id: string | number, body: AdminFeedbackUpdateRequest) {
     return api<void>(withApiBase(`/admin/feedback/${id}`), {
       method: 'PUT',
       body,
+    });
+  },
+
+  remove(id: string | number) {
+    return api<void>(withApiBase(`/admin/feedback/${id}`), {
+      method: 'DELETE',
     });
   },
 };

--- a/src/api/adminForms.ts
+++ b/src/api/adminForms.ts
@@ -2,14 +2,12 @@ import { api, withApiBase } from './client';
 import { unwrapApiResult } from './types';
 import type { ApiResult } from './types';
 
-// ---- 1. Form 목록 조회 (GET /admin/forms) ----
 export type AdminFormListItem = {
   formId: number;
   title: string;
   open: boolean;
 };
 
-// ---- 2. Form 단건 조회 (GET /admin/forms/{formId}) ----
 export type AdminFormNoticeItem = {
   noticeId: number;
   sectionType: string;
@@ -34,7 +32,6 @@ export type AdminFormDetail = {
   questions: AdminFormQuestionInDetail[];
 };
 
-// ---- 3. Form 문항 목록 조회 (GET /admin/forms/{formId}/questions) ----
 export type AdminFormQuestion = {
   formQuestionId: number;
   questionId: number;
@@ -48,13 +45,11 @@ export type AdminFormQuestion = {
   departmentType: string | null;
 };
 
-// ---- 4. Form 생성 (POST /admin/forms) ----
 export type AdminFormCreateRequest = {
   title: string;
   open: boolean;
 };
 
-// ---- 5. 문항 복사 (POST /admin/forms/{targetFormId}/copy) ----
 export type AdminFormCopyQuestionsRequest = {
   sourceFormId: number;
 };
@@ -65,7 +60,6 @@ export type AdminFormCopyResponse = {
   copiedCount: number;
 };
 
-// ---- 6. 문항 추가 (POST /admin/forms/{formId}/questions) ----
 export type AdminFormQuestionCreateRequest = {
   label: string;
   description: string;
@@ -84,7 +78,6 @@ export type AdminFormQuestionAddResponse = {
 
 export type AdminFormQuestionUpdateRequest = AdminFormQuestionCreateRequest;
 
-// ---- 7. 안내문 추가 (POST /admin/forms/{formId}/notices) ----
 export type AdminFormNoticeCreateRequest = {
   sectionType: string;
   departmentType: string | null;
@@ -98,54 +91,43 @@ export type AdminFormNoticeAddResponse = {
 
 export type AdminFormNoticeUpdateRequest = AdminFormNoticeCreateRequest;
 
-/** 안내문 수정/응답용 (단건) */
 export type AdminFormNotice = AdminFormNoticeItem;
 
-/** PUT 문항 수정 / Form OPEN·CLOSE / PUT 안내문 수정 등 200 성공 시 data: {} */
 export type AdminFormEmptyData = Record<string, never>;
 
 export const adminFormsApi = {
-  /** Form 목록 조회 */
   list() {
     return api<ApiResult<AdminFormListItem[]> | AdminFormListItem[]>(
-      withApiBase('/admin/forms')
+      withApiBase('/admin/forms'),
     ).then((res) => unwrapApiResult(res));
   },
 
-  /** Form 단건 조회 */
   getById(formId: string) {
     return api<ApiResult<AdminFormDetail> | AdminFormDetail>(
-      withApiBase(`/admin/forms/${formId}`)
+      withApiBase(`/admin/forms/${formId}`),
     ).then((res) => unwrapApiResult(res));
   },
 
-  /** Form 문항 목록 조회 */
   getQuestions(formId: string) {
     return api<ApiResult<AdminFormQuestion[]> | AdminFormQuestion[]>(
-      withApiBase(`/admin/forms/${formId}/questions`)
+      withApiBase(`/admin/forms/${formId}/questions`),
     ).then((res) => unwrapApiResult(res));
   },
 
-  /** Form 생성 */
   create(body: AdminFormCreateRequest) {
     return api<ApiResult<AdminFormDetail> | AdminFormDetail>(
       withApiBase('/admin/forms'),
-      { method: 'POST', body }
+      { method: 'POST', body },
     ).then((res) => unwrapApiResult(res));
   },
 
-  /** 문항 복사(덮어쓰기) */
-  copyQuestions(
-    targetFormId: string,
-    body: AdminFormCopyQuestionsRequest
-  ) {
+  copyQuestions(targetFormId: string, body: AdminFormCopyQuestionsRequest) {
     return api<ApiResult<AdminFormCopyResponse> | AdminFormCopyResponse>(
       withApiBase(`/admin/forms/${targetFormId}/copy`),
-      { method: 'POST', body }
+      { method: 'POST', body },
     ).then((res) => unwrapApiResult(res));
   },
 
-  /** 문항 추가 */
   addQuestion(formId: string, body: AdminFormQuestionCreateRequest) {
     return api<
       ApiResult<AdminFormQuestionAddResponse> | AdminFormQuestionAddResponse
@@ -155,57 +137,44 @@ export const adminFormsApi = {
     }).then((res) => unwrapApiResult(res));
   },
 
-  /**
-   * Form 문항 수정 (PUT /admin/forms/{formId}/questions/{formQuestionId})
-   * - 400: 규칙 위반/Form 불일치, 404: FormQuestion 없음
-   */
   updateQuestion(
     formId: string,
     formQuestionId: string,
-    body: AdminFormQuestionUpdateRequest
+    body: AdminFormQuestionUpdateRequest,
   ) {
     return api<ApiResult<AdminFormEmptyData> | AdminFormEmptyData>(
       withApiBase(`/admin/forms/${formId}/questions/${formQuestionId}`),
-      { method: 'PUT', body }
+      { method: 'PUT', body },
     ).then((res) => unwrapApiResult(res));
   },
 
-  /**
-   * Form 문항 삭제 (DELETE /admin/forms/{formId}/questions/{formQuestionId})
-   * - 400: Form 불일치, 404: FormQuestion 없음
-   */
   deleteQuestion(formId: string, formQuestionId: string) {
     return api<void>(
       withApiBase(`/admin/forms/${formId}/questions/${formQuestionId}`),
-      { method: 'DELETE' }
+      { method: 'DELETE' },
     );
   },
 
-  /**
-   * Form OPEN (PUT /admin/forms/{formId}/open)
-   * 지정한 Form을 OPEN 상태로 변경합니다. 다른 OPEN Form이 있으면 close 처리합니다.
-   * - 404: Form 없음
-   */
   open(formId: string) {
     return api<ApiResult<AdminFormEmptyData> | AdminFormEmptyData>(
       withApiBase(`/admin/forms/${formId}/open`),
-      { method: 'PUT' }
+      { method: 'PUT' },
     ).then((res) => unwrapApiResult(res));
   },
 
-  /**
-   * Form CLOSE (PUT /admin/forms/{formId}/close)
-   * 지정한 Form을 CLOSE 상태로 변경합니다.
-   * - 404: Form 없음
-   */
   close(formId: string) {
     return api<ApiResult<AdminFormEmptyData> | AdminFormEmptyData>(
       withApiBase(`/admin/forms/${formId}/close`),
-      { method: 'PUT' }
+      { method: 'PUT' },
     ).then((res) => unwrapApiResult(res));
   },
 
-  /** 안내문 추가 */
+  deleteForm(formId: string) {
+    return api<void>(withApiBase(`/admin/forms/${formId}`), {
+      method: 'DELETE',
+    });
+  },
+
   addNotice(formId: string, body: AdminFormNoticeCreateRequest) {
     return api<
       ApiResult<AdminFormNoticeAddResponse> | AdminFormNoticeAddResponse
@@ -215,31 +184,21 @@ export const adminFormsApi = {
     }).then((res) => unwrapApiResult(res));
   },
 
-  /**
-   * 안내문 수정 (PUT /admin/forms/{formId}/notices/{noticeId})
-   * 기존 안내문의 내용, 섹션 타입, 학과 설정을 수정합니다.
-   * - 400: 규칙 위반/Form 불일치, 404: FormNotice 없음
-   */
   updateNotice(
     formId: string,
     noticeId: string,
-    body: AdminFormNoticeUpdateRequest
+    body: AdminFormNoticeUpdateRequest,
   ) {
     return api<ApiResult<AdminFormEmptyData> | AdminFormEmptyData>(
       withApiBase(`/admin/forms/${formId}/notices/${noticeId}`),
-      { method: 'PUT', body }
+      { method: 'PUT', body },
     ).then((res) => unwrapApiResult(res));
   },
 
-  /**
-   * 안내문 삭제 (DELETE /admin/forms/{formId}/notices/{noticeId})
-   * 특정 안내문을 삭제합니다.
-   * - 400: Form 불일치, 404: FormNotice 없음
-   */
   deleteNotice(formId: string, noticeId: string) {
     return api<void>(
       withApiBase(`/admin/forms/${formId}/notices/${noticeId}`),
-      { method: 'DELETE' }
+      { method: 'DELETE' },
     );
   },
 };

--- a/src/pages/admin/AdminFormsListPage.tsx
+++ b/src/pages/admin/AdminFormsListPage.tsx
@@ -1,16 +1,18 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import Reveal from '../../components/Reveal';
-import {
-  adminFormsApi,
-  type AdminFormListItem,
-} from '../../api/adminForms';
+import { adminFormsApi, type AdminFormListItem } from '../../api/adminForms';
+import { ApiError } from '../../api/client';
+import { useToast } from '../../components/toast/useToast';
 
 export default function AdminFormsListPage() {
   const navigate = useNavigate();
+  const toast = useToast();
+
   const [list, setList] = useState<AdminFormListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [deletingFormId, setDeletingFormId] = useState<number | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -19,7 +21,9 @@ export default function AdminFormsListPage() {
       const data = await adminFormsApi.list();
       setList(Array.isArray(data) ? data : []);
     } catch {
-      setError('모집 Form 목록을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.');
+      setError(
+        '모집 Form 목록을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.',
+      );
     } finally {
       setLoading(false);
     }
@@ -28,6 +32,33 @@ export default function AdminFormsListPage() {
   useEffect(() => {
     void load();
   }, [load]);
+
+  const handleDeleteForm = async (form: AdminFormListItem) => {
+    const ok = window.confirm(
+      `"${form.title}" 폼을 삭제할까요?\n활성 폼이거나 지원서가 있으면 삭제할 수 없습니다.`,
+    );
+    if (!ok) return;
+
+    setDeletingFormId(form.formId);
+
+    try {
+      await adminFormsApi.deleteForm(String(form.formId));
+      setList((prev) => prev.filter((x) => x.formId !== form.formId));
+      toast.success('폼을 삭제했어요.');
+    } catch (e) {
+      if (e instanceof ApiError && (e.status === 400 || e.status === 403)) {
+        toast.error('지원서가 존재하는 폼은 삭제할 수 없습니다.');
+      } else {
+        toast.error(
+          e instanceof Error
+            ? e.message
+            : '폼 삭제에 실패했어요. 잠시 후 다시 시도해 주세요.',
+        );
+      }
+    } finally {
+      setDeletingFormId(null);
+    }
+  };
 
   return (
     <div className="mx-auto max-w-6xl px-4 py-12">
@@ -38,7 +69,7 @@ export default function AdminFormsListPage() {
               모집 Form 관리
             </h1>
             <p className="mt-2 text-sm text-slate-600">
-              모집 Form을 만들고 문항·안내문을 설정할 수 있어요
+              모집 Form을 만들고 문항/안내문을 설정할 수 있어요.
             </p>
           </div>
           <button
@@ -46,7 +77,7 @@ export default function AdminFormsListPage() {
             onClick={() => navigate('/admin/forms/new')}
             className="rounded-xl bg-primary px-4 py-2 text-sm font-bold text-white transition hover:opacity-95"
           >
-            새 Form 만들기
+            + Form 만들기
           </button>
         </div>
       </Reveal>
@@ -60,6 +91,7 @@ export default function AdminFormsListPage() {
             불러오는 중...
           </p>
         )}
+
         {error && (
           <p className="py-4 text-sm font-semibold text-rose-600">{error}</p>
         )}
@@ -68,56 +100,69 @@ export default function AdminFormsListPage() {
           <div className="py-12 text-center text-sm text-slate-500">
             <p className="font-semibold">아직 등록된 모집 Form이 없어요.</p>
             <p className="mt-2 text-xs text-slate-400">
-              오른쪽 상단의 새 Form 만들기 버튼을 눌러 추가해 주세요.
+              오른쪽 상단의 + Form 만들기 버튼으로 추가해 주세요.
             </p>
             <button
               type="button"
               onClick={() => navigate('/admin/forms/new')}
               className="mt-4 rounded-xl bg-primary px-4 py-2 text-sm font-bold text-white transition hover:opacity-95"
             >
-              새 Form 만들기
+              + Form 만들기
             </button>
           </div>
         )}
 
         {!loading && !error && list.length > 0 && (
           <div className="grid gap-4">
-            {list.map((form) => (
-              <div
-                key={form.formId}
-                className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm"
-              >
-                <div className="flex items-center gap-3">
-                  <span className="text-lg font-bold text-slate-900">
-                    {form.title}
-                  </span>
-                  <span
-                    className={[
-                      'rounded-full px-2 py-1 text-xs font-semibold',
-                      form.open
-                        ? 'bg-emerald-100 text-emerald-700'
-                        : 'bg-slate-100 text-slate-500',
-                    ].join(' ')}
-                  >
-                    {form.open ? 'OPEN' : 'CLOSE'}
-                  </span>
+            {list.map((form) => {
+              const isDeleting = deletingFormId === form.formId;
+
+              return (
+                <div
+                  key={form.formId}
+                  className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm"
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="text-lg font-bold text-slate-900">
+                      {form.title}
+                    </span>
+                    <span
+                      className={[
+                        'rounded-full px-2 py-1 text-xs font-semibold',
+                        form.open
+                          ? 'bg-emerald-100 text-emerald-700'
+                          : 'bg-slate-100 text-slate-500',
+                      ].join(' ')}
+                    >
+                      {form.open ? 'OPEN' : 'CLOSE'}
+                    </span>
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    <Link
+                      to={`/admin/applications?formId=${form.formId}`}
+                      className="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-bold text-slate-700 hover:bg-slate-100"
+                    >
+                      지원서
+                    </Link>
+                    <Link
+                      to={`/admin/forms/${form.formId}`}
+                      className="rounded-lg border border-primary/30 bg-primary/10 px-3 py-1.5 text-xs font-bold text-primary hover:bg-primary/20"
+                    >
+                      문항·안내문 관리
+                    </Link>
+                    <button
+                      type="button"
+                      onClick={() => void handleDeleteForm(form)}
+                      disabled={isDeleting}
+                      className="rounded-lg border border-rose-200 px-3 py-1.5 text-xs font-bold text-rose-600 hover:bg-rose-50 disabled:opacity-60"
+                    >
+                      {isDeleting ? '삭제 중...' : '삭제'}
+                    </button>
+                  </div>
                 </div>
-                <div className="flex flex-wrap gap-2">
-                  <Link
-                    to={`/admin/applications?formId=${form.formId}`}
-                    className="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-bold text-slate-700 hover:bg-slate-100"
-                  >
-                    지원서
-                  </Link>
-                  <Link
-                    to={`/admin/forms/${form.formId}`}
-                    className="rounded-lg border border-primary/30 bg-primary/10 px-3 py-1.5 text-xs font-bold text-primary hover:bg-primary/20"
-                  >
-                    문항·안내문 관리
-                  </Link>
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </Reveal>


### PR DESCRIPTION
## 작업 개요
관리자 화면에서 피드백/모집폼 삭제 기능을 API와 연결하고, 삭제 실패 시 사용자에게 명확히 보이는 토스트 메시지 UX를 적용

## 변경 사항
- `src/api/adminFeedback.ts`
  - 피드백 삭제 API 연동/정리
- `src/api/adminForms.ts`
  - 모집폼 삭제 API 연동/정리
- `src/pages/admin/AdminFormsListPage.tsx`
  - 폼 삭제 버튼 동작 연결
  - 삭제 성공 시 목록 즉시 반영
  - 삭제 실패(지원서 존재/활성 폼 등) 토스트 메시지 처리 개선
  - FormDetail 화면과 동일한 토스트 스타일/위치로 통일
- `src/pages/admin/AdminFormDetailPage.tsx`
  - 폼 삭제 실패 메시지 처리/표현 정리
- `src/pages/admin/sections/AdminFeedbackListSection.tsx`
  - 피드백 카드 내 삭제 버튼 추가 및 삭제 로직 연결
  - 
## 스크린샷

### 1) 모집 Form 목록 화면 (삭제 버튼 노출)
<img width="2134" height="1222" alt="image" src="https://github.com/user-attachments/assets/2a5292f8-352a-43f8-9286-d8a4b0981e2b" />

### 2) 모집 Form 삭제 실패 토스트 (지원서 존재)
<img width="2057" height="1174" alt="image" src="https://github.com/user-attachments/assets/a49947d5-2496-4822-924f-30d768232d8e" />

### 3) Form 상세 화면 내 삭제 실패 토스트 (동일 UX 적용)
<img width="2509" height="1030" alt="image" src="https://github.com/user-attachments/assets/c8c4120c-ef17-42d4-b28e-774b74310c24" />

### 4) 피드백 목록 화면 (삭제 버튼 추가)
<img width="2149" height="1288" alt="image" src="https://github.com/user-attachments/assets/3f9fd9d2-8b67-4916-903c-bb9a78fad467" />

### 5) 피드백 삭제 성공 직후 (목록 즉시 반영)
<img width="2494" height="829" alt="image" src="https://github.com/user-attachments/assets/68330016-d9c4-426d-8d8b-7819cd31f15f" />

### 6) 피드백 삭제 관련 토스트/상태 메시지 확인
<img width="2496" height="893" alt="image" src="https://github.com/user-attachments/assets/1e8a4da3-3a69-4e76-9824-2f886087ee0d" />