### PR TITLE
Fix: footer 링크 이동 시 스크롤 위치가 유지되는 문제 수정 (페이지 상단 이동 처리)

### DIFF
--- a/src/components/SiteLayout.tsx
+++ b/src/components/SiteLayout.tsx
@@ -83,10 +83,19 @@ export default function SiteLayout() {
     return () => window.clearTimeout(handle);
   }, [slideIndex, notices.length, slides.length]);
 
-  const currentNotice = notices[slideIndex] ?? null;
-
   const location = useLocation();
+  const currentNotice = notices[slideIndex] ?? null;
   const isHome = location.pathname === '/';
+
+  useEffect(() => {
+    if (!location.state || typeof location.state !== 'object') return;
+    if (!('scrollFromFooter' in location.state)) return;
+    if (!location.state.scrollFromFooter) return;
+
+    requestAnimationFrame(() => {
+      window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+    });
+  }, [location.pathname, location.state]);
 
   const showBanner =
     isHome &&
@@ -162,7 +171,7 @@ export default function SiteLayout() {
         <Outlet />
       </main>
 
-      <footer className="mt-100 border-t border-slate-200 bg-white">
+      <footer className="mt-12 border-t border-slate-200 bg-white">
         <div className="mx-auto max-w-6xl px-4 py-10 text-sm text-slate-600">
           <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
             <div>
@@ -185,6 +194,7 @@ export default function SiteLayout() {
                   <li>
                     <Link
                       to="/about"
+                      state={{ scrollFromFooter: true }}
                       className="text-slate-600 hover:text-primary"
                     >
                       소개
@@ -193,6 +203,7 @@ export default function SiteLayout() {
                   <li>
                     <Link
                       to="/projects"
+                      state={{ scrollFromFooter: true }}
                       className="text-slate-600 hover:text-primary"
                     >
                       컬렉션
@@ -201,6 +212,7 @@ export default function SiteLayout() {
                   <li>
                     <Link
                       to="/notices"
+                      state={{ scrollFromFooter: true }}
                       className="text-slate-600 hover:text-primary"
                     >
                       공지사항
@@ -217,6 +229,7 @@ export default function SiteLayout() {
                   <li>
                     <Link
                       to="/apply"
+                      state={{ scrollFromFooter: true }}
                       className="text-slate-600 hover:text-primary"
                     >
                       모집 안내
@@ -225,6 +238,7 @@ export default function SiteLayout() {
                   <li>
                     <Link
                       to="/payouts"
+                      state={{ scrollFromFooter: true }}
                       className="text-slate-600 hover:text-primary"
                     >
                       정산 안내
@@ -241,6 +255,7 @@ export default function SiteLayout() {
                   <li>
                     <Link
                       to="/feedback"
+                      state={{ scrollFromFooter: true }}
                       className="text-slate-600 hover:text-primary"
                     >
                       문의하기
@@ -257,6 +272,7 @@ export default function SiteLayout() {
                   <li>
                     <Link
                       to="/login"
+                      state={{ scrollFromFooter: true }}
                       className="text-slate-500 hover:text-primary"
                     >
                       관리자 로그인


### PR DESCRIPTION
## 변경 내용

- Footer 텍스트 링크(`소개`, `컬렉션`, `공지사항`, `모집 안내`, `정산 안내`, `문의하기`, `관리자 로그인`) 클릭 시,
  이동한 페이지에서 상단으로 자연스럽게 스크롤되도록 수정
- 기존의 `onClick` 즉시 스크롤 방식 대신, 라우트 이동 후에만 스크롤이 실행되도록 처리
- Footer 상단 여백을 조정해 불필요하게 크게 보이던 하단 공백을 줄임

## 적용 결과

- Footer 링크로 페이지 이동 시, 화면이 하단 위치에 남지 않고 페이지 상단부터 바로 확인 가능
- 스크롤 이동이 끊기지 않고 자연스럽게 동작
- Footer 영역의 공백이 이전보다 줄어 레이아웃이 더 안정적으로 보임