### PR TITLE
Fix: 리팩토링 병합 충돌 정리 및 메인/컬렉션 UX 수정 반영

### DIFF
--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type MouseEvent } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Calendar, Pin, Receipt } from 'lucide-react';
 import StatusBadge from './StatusBadge';
@@ -7,19 +7,27 @@ import type { Project } from '../api/projects';
 type ProjectCardProps = {
   project: Project;
   showApplyAction?: boolean;
-  size?: "default" | "large" | "main";
+  size?: 'default' | 'large' | 'main';
 };
 
 export default function ProjectCard({
   project,
   showApplyAction = true,
-  size = "default",
+  size = 'default',
 }: ProjectCardProps) {
-  const canApply = project.status === "OPEN";
-  const deadlineText = project.endAt || "";
-  const isLarge = size === "large";
-  const isMain = size === "main";
+  const navigate = useNavigate();
+  const canApply = project.status === 'OPEN';
+  const deadlineText = project.deadlineDate || project.endAt || '';
+  const isLarge = size === 'large';
+  const isMain = size === 'main';
+  const isClosed = project.status === 'CLOSED';
   const [imgLoaded, setImgLoaded] = useState(false);
+
+  const goPayout = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    navigate(`/payouts?projectId=${project.id}`);
+  };
 
   return (
     <div
@@ -32,7 +40,7 @@ export default function ProjectCard({
         className="flex min-h-0 flex-1 flex-col outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
       >
         <div
-          className={`relative overflow-hidden bg-slate-100 ${isMain ? "h-56" : isLarge ? "h-48" : "h-40"}`}
+          className={`relative overflow-hidden bg-slate-100 ${isMain ? 'h-56' : isLarge ? 'h-48' : 'h-40'}`}
         >
           {project.thumbnailUrl ? (
             <>
@@ -46,9 +54,9 @@ export default function ProjectCard({
                 decoding="async"
                 onLoad={() => setImgLoaded(true)}
                 className={[
-                  "h-full w-full object-cover transition-all duration-300 ease-out group-hover:scale-105",
-                  imgLoaded ? "opacity-100" : "opacity-0",
-                ].join(" ")}
+                  'h-full w-full object-cover transition-all duration-300 ease-out group-hover:scale-105',
+                  imgLoaded ? 'opacity-100' : 'opacity-0',
+                ].join(' ')}
               />
             </>
           ) : (
@@ -78,7 +86,7 @@ export default function ProjectCard({
         <div className="flex flex-1 flex-col p-5">
           <div className="flex items-center justify-between">
             <StatusBadge status={project.status} />
-            {project.status === "CLOSED" ? (
+            {project.status === 'CLOSED' ? (
               <span className="inline-flex items-center gap-1 text-sm text-slate-600 leading-none">
                 <Calendar className="h-4 w-4 text-slate-500" />
                 <span className="font-medium text-slate-700">마감됨</span>
@@ -86,7 +94,7 @@ export default function ProjectCard({
             ) : deadlineText ? (
               <span className="inline-flex items-center gap-1 text-sm text-slate-600 leading-none">
                 <Calendar className="h-4 w-4 text-slate-400" />
-                마감:{" "}
+                마감:{' '}
                 <span className="font-medium text-slate-700">
                   {deadlineText}
                 </span>
@@ -126,7 +134,7 @@ export default function ProjectCard({
               disabled
               className="rounded-xl bg-slate-200 px-4 py-2.5 text-sm font-bold text-slate-500"
             >
-              {project.status === "CLOSED" ? "마감" : "준비중"}
+              {project.status === 'CLOSED' ? '마감' : '준비중'}
             </button>
           ))}
       </div>

--- a/src/components/SiteLayout.tsx
+++ b/src/components/SiteLayout.tsx
@@ -97,7 +97,6 @@ export default function SiteLayout() {
   const canSlideNotices = visibleNotices.length > 1;
 
   const location = useLocation();
-  const currentNotice = notices[slideIndex] ?? null;
   const isHome = location.pathname === '/';
 
   useEffect(() => {

--- a/src/pages/site/ProjectsPage.tsx
+++ b/src/pages/site/ProjectsPage.tsx
@@ -52,7 +52,7 @@ export default function ProjectsPage() {
     placeholderData: (prev) => prev,
   });
 
-  const projects = data ?? [];
+  const projects = useMemo(() => data ?? [], [data]);
 
   const filtered = useMemo(() => {
     return status === 'all'
@@ -152,40 +152,43 @@ export default function ProjectsPage() {
           <>
             {pinnedProjects.length > 0 && (
               <section className="mt-8">
-                <h2 className="text-lg font-bold text-slate-800">추천 프로젝트</h2>
+                <h2 className="text-lg font-bold text-slate-800">
+                  추천 프로젝트
+                </h2>
                 <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
                   {pinnedProjects.map((p, i) => (
                     <Reveal key={p.id} delayMs={i * 40}>
-                        <ProjectCard
-                          project={p}
-                          size="large"
-                          showApplyAction={false}
-                        />
-                      </div>
+                      <ProjectCard
+                        project={p}
+                        size="large"
+                        showApplyAction={false}
+                      />
                     </Reveal>
                   ))}
                 </div>
               </section>
             )}
 
-        {yearSections.map(([year, items], sectionIndex) => (
-          <section key={year} className="mt-10 first:mt-8">
-            <h2 className="text-lg font-bold text-slate-800">
-              {year === '기타' ? '기타' : `${year} 컬렉션`}
-            </h2>
-            <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-              {items.map((p, i) => (
-                <Reveal key={p.id} delayMs={(sectionIndex + i) * 30}>
-                  <ProjectCard
-                    project={p}
-                    size="large"
-                    showApplyAction={false}
-                  />
-                </Reveal>
-              ))}
-            </div>
-          </section>
-        ))}
+            {yearSections.map(([year, items], sectionIndex) => (
+              <section key={year} className="mt-10 first:mt-8">
+                <h2 className="text-lg font-bold text-slate-800">
+                  {year === '기타' ? '기타' : `${year} 컬렉션`}
+                </h2>
+                <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                  {items.map((p, i) => (
+                    <Reveal key={p.id} delayMs={(sectionIndex + i) * 30}>
+                      <ProjectCard
+                        project={p}
+                        size="large"
+                        showApplyAction={false}
+                      />
+                    </Reveal>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## 변경 내용
- 리팩토링(TanStack Query, Skeleton 기반 로딩 UI)과 기존 기능 변경 사항을 충돌 없이 정리
- 메인 공지사항 배너를 데스크톱(버튼) / 모바일(스와이프) 방식으로 동작하도록 정리
- 메인 프로젝트 캐러셀의 데스크톱 탐색(화살표, 1개 단위 이동)과 모바일 스와이프 동작 유지/보완
- 컬렉션 페이지 카드 중복 래퍼를 제거해 카드가 겹쳐 보이던 이슈 수정
- 프로젝트 카드/상세의 `정산` 버튼 UI를 구분되게 통일하고 접근성 라벨 맞춤
- 모바일 footer 간격/정렬 및 footer 링크 이동 시 상단 스크롤 동작 정리

## 결과
- 병합 충돌로 인한 JSX/타입 오류 해소
- 팀원 리팩토링 내용과 기존 UX 개선 사항이 함께 적용된 상태로 빌드 정상 동작
