### PR TITLE
Fix: 캠퍼스 표기명 → 자연캠(용인), 인문캠(서울)로 통일

### DIFF
--- a/src/components/ApplyForm.tsx
+++ b/src/components/ApplyForm.tsx
@@ -201,17 +201,17 @@ export default function ApplyForm({ project }: { project: Project }) {
           <div className="rounded-2xl bg-slate-50 p-4 text-sm text-slate-700">
             <div className="font-bold text-slate-800">판매기간</div>
             <div className="mt-2">
-              [스티커/뱃지] 물품 수령 기간 : 9월 둘째주, 인문캠퍼스
+              [스티커/뱃지] 물품 수령 기간 : 9월 둘째주, 인문캠(서울)
             </div>
             <div className="mt-1">
-              [베이비 마루 키링 인형] 물품 수령 기간 : 12월 첫째주, 인문캠퍼스
+              [베이비 마루 키링 인형] 물품 수령 기간 : 12월 첫째주, 인문캠(서울)
             </div>
             <p className="mt-3 text-xs text-slate-500">
               현장수령 일정은 추석, 중추절로 인해 일정이 변동될 수 있으며,
               상세 일정은 명지공방 인스타그램에 공지됩니다.
             </p>
             <p className="mt-2 text-xs text-slate-500">
-              자연캠퍼스는 택배배송으로만 진행됩니다.
+              자연캠(용인)은 택배배송으로만 진행됩니다.
             </p>
           </div>
 
@@ -313,8 +313,8 @@ export default function ApplyForm({ project }: { project: Project }) {
                 <option value="" disabled>
                   선택
                 </option>
-                <option value="자연캠퍼스">자연캠퍼스</option>
-                <option value="인문캠퍼스">인문캠퍼스</option>
+                <option value="자연캠퍼스">자연캠(용인)</option>
+                <option value="인문캠퍼스">인문캠(서울)</option>
               </select>
             </label>
 
@@ -568,9 +568,9 @@ export default function ApplyForm({ project }: { project: Project }) {
             물품 수령 장소 및 방법
           </div>
           <div className="rounded-2xl bg-slate-50 p-4 text-sm text-slate-700">
-            인문캠퍼스 학생회관 10층 창업동아리실, S21006
+            인문캠(서울) 학생회관 10층 창업동아리실, S21006
             <br />
-            자연캠퍼스는 택배 배송으로만 진행됩니다.
+            자연캠(용인)은 택배 배송으로만 진행됩니다.
           </div>
           <div className="text-xs text-slate-500">
             스티커/뱃지, 인형 수령 방법이 다를 경우 택배 배송을 선택해주세요.

--- a/src/components/order/OrderDetailCard.tsx
+++ b/src/components/order/OrderDetailCard.tsx
@@ -16,8 +16,8 @@ const BUYER_TYPE_LABELS: Record<string, string> = {
 };
 
 const CAMPUS_LABELS: Record<string, string> = {
-  SEOUL: '서울캠퍼스',
-  YONGIN: '자연캠퍼스',
+  SEOUL: '인문캠(서울)',
+  YONGIN: '자연캠(용인)',
 };
 
 const FULFILLMENT_LABELS: Record<string, string> = {

--- a/src/features/mypage/MyPageProfileSection.tsx
+++ b/src/features/mypage/MyPageProfileSection.tsx
@@ -157,8 +157,8 @@ export default function MyPageProfileSection({
               required
             >
               <option value="">선택</option>
-              <option value="SEOUL">인문캠퍼스</option>
-              <option value="YONGIN">자연캠퍼스</option>
+              <option value="SEOUL">인문캠(서울)</option>
+              <option value="YONGIN">자연캠(용인)</option>
             </select>
           )}
         </div>

--- a/src/pages/admin/AdminOrdersPage.tsx
+++ b/src/pages/admin/AdminOrdersPage.tsx
@@ -36,8 +36,8 @@ const BUYER_TYPE_LABELS: Record<string, string> = {
 };
 
 const CAMPUS_LABELS: Record<string, string> = {
-  SEOUL: '서울캠퍼스',
-  YONGIN: '자연캠퍼스',
+  SEOUL: '인문캠(서울)',
+  YONGIN: '자연캠(용인)',
 };
 
 const METHOD_LABELS: Record<string, string> = {

--- a/src/pages/site/OrderPage.tsx
+++ b/src/pages/site/OrderPage.tsx
@@ -162,8 +162,8 @@ const BUYER_TYPE_LABELS: Record<BuyerType, string> = {
 };
 
 const CAMPUS_LABELS: Record<CampusType, string> = {
-  SEOUL: '서울캠퍼스',
-  YONGIN: '자연캠퍼스',
+  SEOUL: '인문캠(서울)',
+  YONGIN: '자연캠(용인)',
 };
 
 const FULFILLMENT_METHOD_LABELS: Record<FulfillmentMethod, string> = {
@@ -797,9 +797,9 @@ export default function OrderPage() {
     draft.lookup.password === draft.lookup.passwordConfirm;
   const campusLabel =
     draft.buyer.campus === 'SEOUL'
-      ? '서울캠퍼스'
+      ? '인문캠(서울)'
       : draft.buyer.campus === 'YONGIN'
-        ? '자연캠퍼스'
+        ? '자연캠(용인)'
         : '미선택';
 
   return (
@@ -1021,8 +1021,8 @@ export default function OrderPage() {
                       }
                       className={SELECT_CLASS}
                     >
-                      <option value="SEOUL">서울캠퍼스</option>
-                      <option value="YONGIN">자연캠퍼스</option>
+                      <option value="SEOUL">인문캠(서울)</option>
+                      <option value="YONGIN">자연캠(용인)</option>
                     </select>
                     <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-slate-400">
                       <svg


### PR DESCRIPTION
## 변경 사항
- 캠퍼스 노출 문구를 아래로 통일
  - `SEOUL` → `인문캠(서울)`
  - `YONGIN` → `자연캠(용인)`
- 저장/전송 값(enum/code)은 유지하고, 화면 라벨만 변경

## 수정 파일
- `src/pages/site/OrderPage.tsx`
- `src/pages/admin/AdminOrdersPage.tsx`
- `src/components/order/OrderDetailCard.tsx`
- `src/features/mypage/MyPageProfileSection.tsx`
- `src/components/ApplyForm.tsx`

## 확인 사항
- 주문서(사용자) 캠퍼스 선택/요약 표기 정상
- 주문 관리(어드민) 캠퍼스 표기 정상
- 주문 상세 카드 캠퍼스 표기 정상
- 마이페이지 프로필 캠퍼스 선택 라벨 정상
- 안내 문구/옵션에서 캠퍼스 표기 일관성 반영

<img width="1696" height="337" alt="image" src="https://github.com/user-attachments/assets/ed79754f-cc45-4054-9574-1ac8a3e25121" />