### PR TITLE
<Feat> GA4 추적 및 footer 상태 표시 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+VITE_API_BASE_URL=https://api.mju-craft.shop/api
+VITE_KAKAO_AUTHORIZE_URL=https://api.mju-craft.shop/api/oauth/kakao/authorize
+VITE_NAVER_AUTHORIZE_URL=https://api.mju-craft.shop/api/oauth/naver/authorize
+VITE_TOKEN_KEY=accessToken
+
+# GA4
+VITE_GA4_MEASUREMENT_ID=G-XXXXXXXXXX
+VITE_GA4_DEBUG_MODE=false
+VITE_SHOW_GA4_FOOTER_BADGE=false
+VITE_GA4_REPORT_URL=

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ src/
 
 - 개발 서버에서 `/api`는 `vite.config.ts`의 프록시 설정을 따릅니다.
 - 배포 환경에서는 `vercel.json` 리라이트 규칙을 사용합니다.
+- GA4를 사용하려면 `VITE_GA4_MEASUREMENT_ID`에 GA4 측정 ID(`G-...`)를 설정합니다.
+- 개발 확인용 footer 배지는 로컬 개발 환경에서 자동 표시되며, 배포 환경에서는 `VITE_SHOW_GA4_FOOTER_BADGE=true`일 때만 표시됩니다.
+- `VITE_GA4_DEBUG_MODE=true`를 설정하면 GA4 DebugView에서 page_view 이벤트를 확인할 수 있습니다.
+- `VITE_GA4_REPORT_URL`에 Analytics 리포트 URL을 넣으면 footer 배지에서 GA4 화면으로 이동할 수 있습니다.
 
 ## 스크립트
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import AdminApplicationDetailPage from './pages/admin/AdminApplicationDetailPage
 import AdminFormsListPage from './pages/admin/AdminFormsListPage';
 import AdminFormDetailPage from './pages/admin/AdminFormDetailPage';
 import FloatingSns from './components/FloatingSns';
+import GoogleAnalytics from './components/GoogleAnalytics';
 
 export default function App() {
   const location = useLocation();
@@ -44,6 +45,7 @@ export default function App() {
 
   return (
     <>
+      <GoogleAnalytics />
       <Routes>
         <Route element={<SiteLayout />}>
           <Route path="/" element={<MainPage />} />

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+import { trackGA4PageView } from '../utils/analytics';
+
+export default function GoogleAnalytics() {
+  const location = useLocation();
+  const lastTrackedPathRef = useRef<string | null>(null);
+  const pagePath = useMemo(
+    () => `${location.pathname}${location.search}${location.hash}`,
+    [location.hash, location.pathname, location.search],
+  );
+
+  useEffect(() => {
+    if (lastTrackedPathRef.current === pagePath) return;
+    lastTrackedPathRef.current = pagePath;
+
+    const frameId = window.requestAnimationFrame(() => {
+      trackGA4PageView(pagePath);
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [pagePath]);
+
+  return null;
+}

--- a/src/components/GoogleAnalyticsFooterStatus.tsx
+++ b/src/components/GoogleAnalyticsFooterStatus.tsx
@@ -1,0 +1,49 @@
+import {
+  GA4_DEBUG_MODE,
+  GA4_MEASUREMENT_ID,
+  GA4_REPORT_URL,
+  SHOW_GA4_FOOTER_BADGE,
+  isGA4Enabled,
+} from '../utils/analytics';
+
+export default function GoogleAnalyticsFooterStatus() {
+  if (!SHOW_GA4_FOOTER_BADGE) return null;
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-2 text-[11px] text-slate-400"
+      aria-label="GA4 개발자 상태"
+    >
+      <span className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1">
+        <span
+          className={[
+            'h-1.5 w-1.5 rounded-full',
+            isGA4Enabled ? 'bg-emerald-500' : 'bg-slate-300',
+          ].join(' ')}
+        />
+        <span>{isGA4Enabled ? 'GA4 connected' : 'GA4 disabled'}</span>
+      </span>
+
+      {isGA4Enabled && (
+        <span className="font-mono text-slate-400">{GA4_MEASUREMENT_ID}</span>
+      )}
+
+      {GA4_DEBUG_MODE && (
+        <span className="rounded-full border border-blue-100 bg-blue-50 px-2.5 py-1 font-medium text-blue-600">
+          DebugView
+        </span>
+      )}
+
+      {GA4_REPORT_URL && (
+        <a
+          href={GA4_REPORT_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="font-medium text-slate-500 underline-offset-2 hover:text-primary hover:underline"
+        >
+          GA4 보기
+        </a>
+      )}
+    </div>
+  );
+}

--- a/src/components/SiteLayout.tsx
+++ b/src/components/SiteLayout.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, Outlet, useLocation } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import Header from './Header';
+import GoogleAnalyticsFooterStatus from './GoogleAnalyticsFooterStatus';
 import { noticesApi } from '../api/notices';
 import { formatYmd, parseDateLike } from '../utils/date';
 
@@ -317,10 +318,13 @@ export default function SiteLayout() {
               © {new Date().getFullYear()} MJU Craft Studio. All rights
               reserved.
             </p>
-            <p>
-              Designed &amp; built by{' '}
-              <span className="font-semibold text-slate-500">COW</span>
-            </p>
+            <div className="flex flex-col items-start gap-2 md:items-end">
+              <p>
+                Designed &amp; built by{' '}
+                <span className="font-semibold text-slate-500">COW</span>
+              </p>
+              {isHome && <GoogleAnalyticsFooterStatus />}
+            </div>
           </div>
         </div>
       </footer>

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,89 @@
+export const GA4_MEASUREMENT_ID = (
+  import.meta.env.VITE_GA4_MEASUREMENT_ID ?? ''
+).trim();
+
+export const GA4_DEBUG_MODE = import.meta.env.VITE_GA4_DEBUG_MODE === 'true';
+
+export const GA4_REPORT_URL = (import.meta.env.VITE_GA4_REPORT_URL ?? '').trim();
+
+export const SHOW_GA4_FOOTER_BADGE =
+  import.meta.env.DEV || import.meta.env.VITE_SHOW_GA4_FOOTER_BADGE === 'true';
+
+export const isGA4Enabled = GA4_MEASUREMENT_ID.length > 0;
+
+type GtagConfigParams = {
+  debug_mode?: boolean;
+  page_location?: string;
+  page_path?: string;
+  page_title?: string;
+  send_page_view?: boolean;
+};
+
+type GtagEventParams = {
+  debug_mode?: boolean;
+  page_location?: string;
+  page_path?: string;
+  page_title?: string;
+};
+
+type GtagCommand =
+  | ['js', Date]
+  | ['config', string, GtagConfigParams]
+  | ['event', string, GtagEventParams];
+
+declare global {
+  interface Window {
+    dataLayer?: GtagCommand[];
+    gtag?: (...args: GtagCommand) => void;
+  }
+}
+
+let initialized = false;
+
+const getDebugParams = () => (GA4_DEBUG_MODE ? { debug_mode: true } : {});
+
+const appendGtagScript = () => {
+  if (document.getElementById('ga4-gtag-script')) return;
+
+  const script = document.createElement('script');
+  script.id = 'ga4-gtag-script';
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(
+    GA4_MEASUREMENT_ID,
+  )}`;
+
+  document.head.appendChild(script);
+};
+
+export const initializeGA4 = () => {
+  if (!isGA4Enabled || initialized || typeof window === 'undefined') return;
+
+  window.dataLayer = window.dataLayer ?? [];
+  window.gtag =
+    window.gtag ??
+    ((...args: GtagCommand) => {
+      window.dataLayer?.push(args);
+    });
+
+  appendGtagScript();
+  window.gtag('js', new Date());
+  window.gtag('config', GA4_MEASUREMENT_ID, {
+    send_page_view: false,
+    ...getDebugParams(),
+  });
+
+  initialized = true;
+};
+
+export const trackGA4PageView = (path: string) => {
+  if (!isGA4Enabled || typeof window === 'undefined') return;
+
+  initializeGA4();
+
+  window.gtag?.('event', 'page_view', {
+    page_path: path,
+    page_location: window.location.href,
+    page_title: document.title,
+    ...getDebugParams(),
+  });
+};


### PR DESCRIPTION
## 작업 내용

- GA4 측정 ID 기반 추적 로직을 추가했습니다.
- React Router 경로 변경 시 `page_view` 이벤트를 GA4로 전송하도록 했습니다.
- 홈 footer에서 개발자가 GA4 연결 상태를 확인할 수 있는 배지를 추가했습니다.
- GA4 관련 환경변수 예시와 README 설명을 추가했습니다.

