### PR TITLE
<Fix> production에서 GA4 디버그 배지 노출되는 문제 수정

### DIFF
--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -2,12 +2,13 @@ export const GA4_MEASUREMENT_ID = (
   import.meta.env.VITE_GA4_MEASUREMENT_ID ?? ''
 ).trim();
 
-export const GA4_DEBUG_MODE = import.meta.env.VITE_GA4_DEBUG_MODE === 'true';
+export const GA4_DEBUG_MODE =
+  import.meta.env.DEV && import.meta.env.VITE_GA4_DEBUG_MODE === 'true';
 
 export const GA4_REPORT_URL = (import.meta.env.VITE_GA4_REPORT_URL ?? '').trim();
 
 export const SHOW_GA4_FOOTER_BADGE =
-  import.meta.env.DEV || import.meta.env.VITE_SHOW_GA4_FOOTER_BADGE === 'true';
+  import.meta.env.DEV && import.meta.env.VITE_SHOW_GA4_FOOTER_BADGE === 'true';
 
 export const isGA4Enabled = GA4_MEASUREMENT_ID.length > 0;
 


### PR DESCRIPTION
## 문제
운영 사이트 하단에 GA4 디버그 UI(GA4 connected, DebugView, 측정 ID)가
사용자에게 노출되고 있었습니다.

## 원인
Vercel 대시보드에 `VITE_GA4_DEBUG_MODE=true`, `VITE_SHOW_GA4_FOOTER_BADGE=true`가
설정되어 있어, `.env`의 값과 무관하게 production 번들에 포함됐습니다.

## 수정 내용
`src/utils/analytics.ts`에서 `DEV &&` 조건을 추가해 코드 레벨에서 차단

```ts
// 변경 전 — Vercel env var가 true면 production에도 노출됨
export const GA4_DEBUG_MODE = import.meta.env.VITE_GA4_DEBUG_MODE === 'true';
export const SHOW_GA4_FOOTER_BADGE =
  import.meta.env.DEV || import.meta.env.VITE_SHOW_GA4_FOOTER_BADGE === 'true';

// 변경 후 — production 빌드에서 DEV가 false로 교체되어 항상 비활성화
export const GA4_DEBUG_MODE =
  import.meta.env.DEV && import.meta.env.VITE_GA4_DEBUG_MODE === 'true';
export const SHOW_GA4_FOOTER_BADGE =
  import.meta.env.DEV && import.meta.env.VITE_SHOW_GA4_FOOTER_BADGE === 'true';
