### PR TITLE
fix: 지원서 운영 라벨을 기획으로 변경

### DIFF
--- a/src/types/recruit.ts
+++ b/src/types/recruit.ts
@@ -15,7 +15,7 @@ export const DEPARTMENT_OPTIONS: Array<{ value: DepartmentType; label: string }>
   { value: 'MARKETING', label: '마케팅' },
   { value: 'DESIGN', label: '디자인' },
   { value: 'FINANCE', label: '재무' },
-  { value: 'OPERATION', label: '운영' },
+  { value: 'OPERATION', label: '기획' },
 ];
 
 export function getDepartmentLabel(value: DepartmentType | string | null): string {


### PR DESCRIPTION
## Summary
- 지원서 부서 선택지의 OPERATION 화면 표기를 운영에서 기획으로 변경했습니다.
- 백엔드 enum 값(OPERATION)은 유지해 API 호환성을 보존했습니다.

## Test
- npm run build