### PR TITLE
fix: 지원서 화면 API 연동 및 입력 UX 개선

### DIFF
--- a/src/components/AutoResizeTextarea.tsx
+++ b/src/components/AutoResizeTextarea.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useRef, type TextareaHTMLAttributes } from 'react';
+
+export default function AutoResizeTextarea({
+  className,
+  value,
+  ...props
+}: TextareaHTMLAttributes<HTMLTextAreaElement>) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+
+  const resize = () => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  };
+
+  useEffect(() => {
+    resize();
+  }, [value]);
+
+  return (
+    <textarea
+      {...props}
+      ref={ref}
+      rows={1}
+      value={value}
+      onInput={resize}
+      className={`resize-none overflow-hidden ${className ?? ''}`}
+    />
+  );
+}

--- a/src/components/FloatingSns.tsx
+++ b/src/components/FloatingSns.tsx
@@ -44,13 +44,13 @@ export default function FloatingSns() {
   const kakaoUrl = snsLinks?.kakaoUrl ?? null;
 
   return (
-    <div className="fixed bottom-4 right-4 z-50 flex flex-col items-end gap-2.5 md:bottom-6 md:right-6 md:gap-3">
+    <div className="fixed bottom-6 right-6 z-50 hidden flex-col items-end gap-3 md:flex">
       {instagramUrl && (
         <a
           href={instagramUrl}
           target="_blank"
           rel="noreferrer"
-          className="h-11 w-11 overflow-hidden rounded-full shadow-lg md:h-13 md:w-13"
+          className="h-13 w-13 overflow-hidden rounded-full shadow-lg"
           aria-label="Instagram"
         >
           <img
@@ -66,7 +66,7 @@ export default function FloatingSns() {
           href={kakaoUrl}
           target="_blank"
           rel="noreferrer"
-          className="h-11 w-11 overflow-hidden rounded-full shadow-lg md:h-13 md:w-13"
+          className="h-13 w-13 overflow-hidden rounded-full shadow-lg"
           aria-label="Kakao"
         >
           <img
@@ -80,7 +80,7 @@ export default function FloatingSns() {
       <button
         type="button"
         onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-        className="h-11 w-11 rounded-full bg-[#002968] text-[11px] font-bold text-white shadow-lg md:h-13 md:w-13 md:text-sm"
+        className="h-13 w-13 rounded-full bg-[#002968] text-sm font-bold text-white shadow-lg"
       >
         TOP
       </button>

--- a/src/pages/site/ApplyEntryPage.tsx
+++ b/src/pages/site/ApplyEntryPage.tsx
@@ -1,95 +1,88 @@
 import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { ArrowRight } from 'lucide-react';
 import Reveal from '../../components/Reveal';
-import { FilePenLine, FileSearch, Trophy } from 'lucide-react';
+import { applicationsApi } from '../../api/applications';
 
 const ACTIONS = [
-  {
-    to: '/apply/new',
-    title: '지원하기',
-    description: '현재 모집 중인 지원서 양식을 작성합니다.',
-    icon: FilePenLine,
-    accent: 'from-sky-500 to-indigo-500',
-  },
-  {
-    to: '/apply/manage',
-    title: '지원서 조회/수정',
-    description:
-      '지원서 작성 시 입력한 학번/비밀번호로 지원서를 확인하고 수정합니다.',
-    icon: FileSearch,
-    accent: 'from-emerald-500 to-cyan-500',
-  },
-  {
-    to: '/apply/result',
-    title: '결과 조회',
-    description:
-      '지원서 작성 시 입력한 학번/비밀번호로 미발표/합격/불합격 여부를 확인합니다.',
-    icon: Trophy,
-    accent: 'from-amber-500 to-orange-500',
-  },
+  { to: '/apply/new', title: '지원하기', hint: '모집 중인 지원서 양식 작성' },
+  { to: '/apply/manage', title: '지원서 조회/수정', hint: '학번 · 비밀번호 필요' },
+  { to: '/apply/result', title: '결과 조회', hint: '학번 · 비밀번호 필요' },
 ];
 
 export default function ApplyEntryPage() {
+  const { data: activeForm } = useQuery({
+    queryKey: ['applicationForm'],
+    queryFn: () => applicationsApi.getForm(),
+    staleTime: 1000 * 60 * 5,
+    retry: false,
+  });
+
   return (
     <div className="mx-auto max-w-6xl px-4 py-12">
       <Reveal>
-        <div className="flex flex-wrap items-end justify-between gap-4">
-          <div>
-            <Link
-              to="/"
-              className="inline-flex items-center gap-2 font-heading text-3xl text-primary hover:opacity-90"
-            >
-              <svg
-                width="18"
-                height="18"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden="true"
-              >
-                <path d="M15 18l-6-6 6-6" />
-              </svg>
-              지원하기
-            </Link>
-          </div>
-          <p className="mt-2 text-sm text-slate-600">
-            원하는 기능을 선택해 진행해주세요.
-          </p>
+        <Link
+          to="/"
+          className="inline-flex items-center gap-2 font-heading text-3xl text-primary hover:opacity-90"
+        >
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M15 18l-6-6 6-6" />
+          </svg>
+          지원하기
+        </Link>
+      </Reveal>
+
+      <Reveal delayMs={60} className="mt-8">
+        <div className="flex items-center gap-4 rounded-2xl border border-slate-200 bg-white px-7 py-5">
+          {activeForm ? (
+            <>
+              <span className="shrink-0 rounded-full bg-emerald-50 px-3 py-1 text-xs font-bold text-emerald-600">
+                모집중
+              </span>
+              <p className="min-w-0 flex-1 truncate text-lg font-bold text-slate-900">
+                {activeForm.title ?? '지원서 양식'}
+              </p>
+            </>
+          ) : (
+            <>
+              <span className="shrink-0 rounded-full bg-slate-100 px-3 py-1 text-xs font-bold text-slate-500">
+                모집 없음
+              </span>
+              <p className="text-sm text-slate-500">
+                현재 모집 중인 지원서가 없어요.
+              </p>
+            </>
+          )}
         </div>
       </Reveal>
 
-      <Reveal delayMs={80} className="mt-8">
+      <Reveal delayMs={120} className="mt-4">
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {ACTIONS.map((action) => (
             <Link
               key={action.to}
               to={action.to}
-              className="group relative overflow-hidden rounded-3xl border border-slate-200 bg-white px-5 py-6 text-center shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-slate-300 hover:shadow-xl hover:shadow-slate-300/40"
+              className="group flex items-center justify-between gap-4 rounded-2xl border border-slate-200 bg-white px-7 py-6 transition-all duration-300 hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-lg hover:shadow-slate-200/60"
             >
-              <div
-                className={[
-                  'mx-auto mb-4 inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-linear-to-br text-white shadow-md',
-                  action.accent,
-                ].join(' ')}
-              >
-                <action.icon className="h-5 w-5" />
+              <div>
+                <p className="text-lg font-bold text-slate-900">
+                  {action.title}
+                </p>
+                <p className="mt-1 text-sm text-slate-400">{action.hint}</p>
               </div>
-
-              <p className="text-lg font-extrabold tracking-tight text-slate-900 transition-colors group-hover:text-primary">
-                {action.title}
-              </p>
-              <p className="mt-2 text-sm leading-relaxed text-slate-500">
-                {action.description}
-              </p>
-
-              <div
-                className={[
-                  'pointer-events-none absolute inset-x-0 bottom-0 h-1 bg-linear-to-br opacity-0 transition-opacity duration-300 group-hover:opacity-100',
-                  action.accent,
-                ].join(' ')}
-              />
+              <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/5 text-primary transition-colors group-hover:bg-primary group-hover:text-white">
+                <ArrowRight className="h-[18px] w-[18px]" />
+              </span>
             </Link>
           ))}
         </div>

--- a/src/pages/site/ApplyPage.tsx
+++ b/src/pages/site/ApplyPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Reveal from '../../components/Reveal';
 import { AlertCircle } from 'lucide-react';
+import AutoResizeTextarea from '../../components/AutoResizeTextarea';
 import {
   applicationsApi,
   type ApplicationFormResponse,
@@ -715,7 +716,7 @@ export default function ApplyPage() {
                     })}
                   </div>
                 ) : (
-                  <input
+                  <AutoResizeTextarea
                     value={String(value ?? '')}
                     onChange={(e) =>
                       handleAnswerChange(q.formQuestionId, e.target.value)
@@ -907,7 +908,7 @@ export default function ApplyPage() {
                         })}
                       </div>
                     ) : (
-                      <input
+                      <AutoResizeTextarea
                         value={String(value ?? '')}
                         onChange={(e) =>
                           handleAnswerChange(q.formQuestionId, e.target.value)
@@ -1101,7 +1102,7 @@ export default function ApplyPage() {
                         })}
                       </div>
                     ) : (
-                      <input
+                      <AutoResizeTextarea
                         value={String(value ?? '')}
                         onChange={(e) =>
                           handleAnswerChange(q.formQuestionId, e.target.value)
@@ -1266,7 +1267,7 @@ export default function ApplyPage() {
                     })}
                   </div>
                 ) : (
-                  <input
+                  <AutoResizeTextarea
                     value={String(value ?? '')}
                     onChange={(e) =>
                       handleAnswerChange(q.formQuestionId, e.target.value)


### PR DESCRIPTION
## 요약
- 지원서 진입 화면을 현재 모집 중인 지원서 정보와 간결한 액션 목록 중심으로 정리했습니다.
- 지원서 양식 조회를 실제 백엔드 Swagger 기준 엔드포인트인 /api/application/form 경로로 연결했습니다.
- 주관식 답변 입력 영역을 자동 높이 조절 textarea로 바꿔 긴 답변 작성 UX를 개선했습니다.
- 모바일 작성 화면에서 플로팅 SNS/TOP 버튼이 입력칸을 덮지 않도록 md 이상에서만 노출되게 조정했습니다.

## 반응형 확인
- 390x844 모바일 /apply: 1열 카드 배치, 가로 스크롤 없음
- 390x844 모바일 /apply/new: 구간별 스크롤 확인, 플로팅 SNS/TOP 미노출, 가로 스크롤 없음
- 1440x900 데스크톱 /apply/new: 플로팅 SNS/TOP 노출 유지, 가로 스크롤 없음

## 검증
- npm run build
- npx eslint src/pages/site/ApplyEntryPage.tsx src/pages/site/ApplyPage.tsx src/components/AutoResizeTextarea.tsx src/components/FloatingSns.tsx
- npm run lint는 기존 파일의 hook/fast-refresh/any 오류로 실패합니다. 이번 변경 파일 대상 ESLint는 통과했습니다.