### PR TITLE
feat: 지원서 관리 화면 개선

### DIFF
--- a/src/api/adminApplications.ts
+++ b/src/api/adminApplications.ts
@@ -6,6 +6,7 @@ export type AdminApplicationResultStatus = 'PASS' | 'FAIL' | 'NOT_PUBLISHED';
 export type AdminApplicationListItem = {
   applicationId: number;
   studentId: string;
+  applicantName?: string | null;
   firstDepartment: DepartmentType;
   secondDepartment: DepartmentType;
   resultStatus: AdminApplicationResultStatus;
@@ -17,16 +18,21 @@ export type AdminApplicationAnswerItem = {
   formQuestionId: number;
   value: string | null;
   fileUrl?: string | null;
+  previewUrl?: string | null;
+  downloadUrl?: string | null;
+  fileName?: string | null;
 };
 
 export type AdminApplicationDetail = {
   applicationId: number;
   studentId: string;
+  applicantName?: string | null;
   firstDepartment: DepartmentType;
   secondDepartment: DepartmentType;
   resultStatus: AdminApplicationResultStatus;
   createdAt?: string | number[] | null;
   updatedAt?: string | number[] | null;
+  basicAnswers?: AdminApplicationAnswerItem[];
   commonAnswers?: AdminApplicationAnswerItem[];
   firstDepartmentAnswers?: AdminApplicationAnswerItem[];
   secondDepartmentAnswers?: AdminApplicationAnswerItem[];

--- a/src/components/AdminHeaderDesktop.tsx
+++ b/src/components/AdminHeaderDesktop.tsx
@@ -13,7 +13,7 @@ const LEADING_NAV_ITEMS = [
 const TRAILING_NAV_ITEMS = [
   { key: 'projects', label: '프로젝트/상품', href: '/admin/projects' },
   { key: 'notices', label: '공지사항', href: '/admin/notices' },
-  { key: 'forms', label: '모집 양식', href: '/admin/forms' },
+  { key: 'forms', label: '지원서 관리', href: '/admin/forms' },
   { key: 'payouts', label: '정산', href: '/admin#payouts' },
 ];
 

--- a/src/components/AdminHeaderMobile.tsx
+++ b/src/components/AdminHeaderMobile.tsx
@@ -15,7 +15,7 @@ const LEADING_NAV_ITEMS = [
 const TRAILING_NAV_ITEMS = [
   { key: 'projects', label: '프로젝트/상품', href: '/admin/projects' },
   { key: 'notices', label: '공지사항', href: '/admin/notices' },
-  { key: 'forms', label: '모집 양식', href: '/admin/forms' },
+  { key: 'forms', label: '지원서 관리', href: '/admin/forms' },
   { key: 'payouts', label: '정산', href: '/admin#payouts' },
 ];
 

--- a/src/components/AdminLayout.tsx
+++ b/src/components/AdminLayout.tsx
@@ -5,10 +5,6 @@ import AdminHeaderMobile from './AdminHeaderMobile';
 import { isLoggedIn } from '../utils/auth';
 
 export default function AdminLayout() {
-  if (!isLoggedIn()) {
-    return <Navigate to="/login" replace />;
-  }
-
   const location = useLocation();
   const [mobileHeaderVisible, setMobileHeaderVisible] = useState(true);
   const lastScrollYRef = useRef(0);
@@ -70,6 +66,10 @@ export default function AdminLayout() {
       window.removeEventListener('resize', handleResize);
     };
   }, []);
+
+  if (!isLoggedIn()) {
+    return <Navigate to="/login" replace />;
+  }
 
   return (
     <div className="min-h-screen overflow-x-hidden bg-app-bg text-slate-900">

--- a/src/components/ApplyForm.tsx
+++ b/src/components/ApplyForm.tsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useMemo, useState } from 'react';
+﻿import { useMemo, useState } from 'react';
 import type { Project } from '../api/projects';
 
 type Step = 1 | 2 | 3 | 4 | 5;
@@ -75,12 +75,6 @@ export default function ApplyForm({ project }: { project: Project }) {
     depositDate: '',
     depositAmount: '',
   });
-
-  useEffect(() => {
-    if (buyer.campus === '자연캠퍼스') {
-      setPickup((prev) => ({ ...prev, method: '택배 배송' }));
-    }
-  }, [buyer.campus]);
 
   const totalOrderQty =
     order.stickerQty + order.badgeQty + order.keyringQty;
@@ -302,12 +296,16 @@ export default function ApplyForm({ project }: { project: Project }) {
               </div>
               <select
                 value={buyer.campus}
-                onChange={(e) =>
+                onChange={(e) => {
+                  const campus = e.target.value as BuyerInfo['campus'];
                   setBuyer((prev) => ({
                     ...prev,
-                    campus: e.target.value as BuyerInfo['campus'],
-                  }))
-                }
+                    campus,
+                  }));
+                  if (campus === '자연캠퍼스') {
+                    setPickup((prev) => ({ ...prev, method: '택배 배송' }));
+                  }
+                }}
                 className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm outline-none focus:border-primary/60"
               >
                 <option value="" disabled>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,8 +16,13 @@ export default function Header() {
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    setMobileHeaderVisible(true);
+    const frame = window.requestAnimationFrame(() => {
+      setMobileHeaderVisible(true);
+    });
     lastScrollYRef.current = window.scrollY;
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
   }, [location.hash, location.pathname, location.search]);
 
   useEffect(() => {

--- a/src/components/SiteLayout.tsx
+++ b/src/components/SiteLayout.tsx
@@ -30,10 +30,15 @@ export default function SiteLayout() {
   }, [noticesData]);
 
   useEffect(() => {
-    setSlideIndex((prev) => {
-      if (visibleNotices.length === 0) return 0;
-      return Math.min(prev, visibleNotices.length - 1);
+    const frame = window.requestAnimationFrame(() => {
+      setSlideIndex((prev) => {
+        if (visibleNotices.length === 0) return 0;
+        return Math.min(prev, visibleNotices.length - 1);
+      });
     });
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
   }, [visibleNotices.length]);
 
   const moveNotice = useCallback(

--- a/src/components/confirm/ConfirmContext.ts
+++ b/src/components/confirm/ConfirmContext.ts
@@ -1,0 +1,17 @@
+import { createContext } from 'react';
+
+export type ConfirmOptions = {
+  title: string;
+  description?: string;
+  confirmText?: string;
+  cancelText?: string;
+  danger?: boolean;
+  confirmDisabled?: boolean;
+};
+
+export type ConfirmContextValue = {
+  open: (options: ConfirmOptions) => Promise<boolean>;
+  run: (options: ConfirmOptions, action: () => Promise<void>) => Promise<boolean>;
+};
+
+export const ConfirmContext = createContext<ConfirmContextValue | null>(null);

--- a/src/components/confirm/ConfirmProvider.tsx
+++ b/src/components/confirm/ConfirmProvider.tsx
@@ -1,35 +1,12 @@
-import {
-  createContext,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type PropsWithChildren,
-} from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type PropsWithChildren } from 'react';
 import ConfirmModal from '../ConfirmModal';
-
-export type ConfirmOptions = {
-  title: string;
-  description?: string;
-  confirmText?: string;
-  cancelText?: string;
-  danger?: boolean;
-  confirmDisabled?: boolean;
-};
-
-type ConfirmContextValue = {
-  open: (options: ConfirmOptions) => Promise<boolean>;
-  run: (options: ConfirmOptions, action: () => Promise<void>) => Promise<boolean>;
-};
+import { ConfirmContext, type ConfirmOptions } from './ConfirmContext';
 
 type ConfirmState = {
   open: boolean;
   loading: boolean;
   options: ConfirmOptions;
 };
-
-export const ConfirmContext = createContext<ConfirmContextValue | null>(null);
 
 const DEFAULT_OPTIONS: ConfirmOptions = {
   title: '확인',

--- a/src/components/confirm/useConfirm.ts
+++ b/src/components/confirm/useConfirm.ts
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { ConfirmContext } from './ConfirmProvider';
+import { ConfirmContext } from './ConfirmContext';
 
 export function useConfirm() {
   const context = useContext(ConfirmContext);

--- a/src/components/toast/ToastContext.ts
+++ b/src/components/toast/ToastContext.ts
@@ -1,0 +1,19 @@
+import { createContext } from 'react';
+
+export type ToastType = 'success' | 'error' | 'info';
+
+export type ToastPayload = {
+  type: ToastType;
+  message: string;
+  durationMs?: number;
+};
+
+export type ToastContextValue = {
+  show: (payload: ToastPayload) => void;
+  success: (message: string, durationMs?: number) => void;
+  error: (message: string, durationMs?: number) => void;
+  info: (message: string, durationMs?: number) => void;
+  clear: () => void;
+};
+
+export const ToastContext = createContext<ToastContextValue | null>(null);

--- a/src/components/toast/ToastProvider.tsx
+++ b/src/components/toast/ToastProvider.tsx
@@ -1,28 +1,11 @@
-import { createContext, useCallback, useEffect, useMemo, useRef, useState, type PropsWithChildren } from 'react';
-
-export type ToastType = 'success' | 'error' | 'info';
-
-export type ToastPayload = {
-  type: ToastType;
-  message: string;
-  durationMs?: number;
-};
-
-type ToastContextValue = {
-  show: (payload: ToastPayload) => void;
-  success: (message: string, durationMs?: number) => void;
-  error: (message: string, durationMs?: number) => void;
-  info: (message: string, durationMs?: number) => void;
-  clear: () => void;
-};
+import { useCallback, useEffect, useMemo, useRef, useState, type PropsWithChildren } from 'react';
+import { ToastContext, type ToastPayload, type ToastType } from './ToastContext';
 
 type ToastState = {
   type: ToastType;
   message: string;
   durationMs: number;
 } | null;
-
-export const ToastContext = createContext<ToastContextValue | null>(null);
 
 const DEFAULT_DURATION_MS = 3000;
 

--- a/src/components/toast/useToast.ts
+++ b/src/components/toast/useToast.ts
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { ToastContext } from './ToastProvider';
+import { ToastContext } from './ToastContext';
 
 export function useToast() {
   const context = useContext(ToastContext);

--- a/src/pages/admin/AdminApplicationDetailPage.tsx
+++ b/src/pages/admin/AdminApplicationDetailPage.tsx
@@ -37,13 +37,28 @@ function isLikelyFileKey(value: string) {
   );
 }
 
+function getDisplayFileName(answer: AdminApplicationAnswerItem) {
+  const fromServer = answer.fileName?.trim();
+  if (fromServer) return fromServer;
+
+  const value = answer.value?.trim() ?? '';
+  if (!value) return '첨부 파일';
+  if (isLikelyUrl(value)) return value;
+
+  const lastSegment = value.split('/').filter(Boolean).pop() ?? value;
+  return lastSegment.replace(
+    /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}-/,
+    '',
+  );
+}
+
 function getQuestionLabel(
   questionMap: Record<number, AdminFormQuestion>,
   formQuestionId: number,
 ) {
   const q = questionMap[formQuestionId];
-  if (!q) return `Q#${formQuestionId}`;
-  return q.label?.trim() || `Q#${formQuestionId}`;
+  if (!q) return '질문';
+  return q.label?.trim() || '질문';
 }
 
 function getQuestionAnswerType(
@@ -67,8 +82,11 @@ function AnswerCard({
   const fileLike =
     answerType.includes('FILE') || isLikelyUrl(value) || isLikelyFileKey(value);
 
-  const fileUrl = (answer.fileUrl ?? '').trim();
-  const hasFileUrl = /^https?:\/\//i.test(fileUrl);
+  const previewUrl = (answer.previewUrl ?? answer.fileUrl ?? '').trim();
+  const downloadUrl = (answer.downloadUrl ?? answer.fileUrl ?? '').trim();
+  const hasPreviewUrl = /^https?:\/\//i.test(previewUrl);
+  const hasDownloadUrl = /^https?:\/\//i.test(downloadUrl);
+  const displayFileName = getDisplayFileName(answer);
 
   const handleCopy = async () => {
     if (!value) return;
@@ -85,36 +103,47 @@ function AnswerCard({
       <p className="text-xs font-semibold text-slate-500">
         {getQuestionLabel(questionMap, answer.formQuestionId)}
       </p>
-      <p className="mt-0.5 text-[11px] text-slate-400">
-        Q#{answer.formQuestionId}
-      </p>
 
       {!value ? (
         <p className="mt-2 text-sm text-slate-500">응답 없음</p>
       ) : fileLike ? (
         <div className="mt-2 rounded-lg border border-slate-200 bg-white p-3">
-          <p className="truncate text-xs text-slate-500">{value}</p>
+          <p className="truncate text-sm font-semibold text-slate-700">
+            {displayFileName}
+          </p>
 
           <div className="mt-2 flex flex-wrap gap-2">
-            {hasFileUrl ? (
+            {hasPreviewUrl && (
               <a
-                href={fileUrl}
+                href={previewUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50"
               >
-                파일 열기/다운로드
+                미리보기
               </a>
-            ) : isLikelyUrl(value) ? (
+            )}
+            {hasDownloadUrl && (
+              <a
+                href={downloadUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-white hover:opacity-95"
+              >
+                다운로드
+              </a>
+            )}
+            {!hasPreviewUrl && !hasDownloadUrl && isLikelyUrl(value) && (
               <a
                 href={value}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50"
               >
-                파일 열기/다운로드
+                파일 열기
               </a>
-            ) : (
+            )}
+            {!hasPreviewUrl && !hasDownloadUrl && !isLikelyUrl(value) && (
               <button
                 type="button"
                 onClick={() => void handleCopy()}
@@ -125,9 +154,9 @@ function AnswerCard({
             )}
           </div>
 
-          {!hasFileUrl && !isLikelyUrl(value) && (
+          {!hasPreviewUrl && !hasDownloadUrl && !isLikelyUrl(value) && (
             <p className="mt-2 text-[11px] text-amber-600">
-              fileUrl이 없어 파일 키만 표시합니다.
+              파일 링크가 없어 파일 키만 복사할 수 있어요.
             </p>
           )}
         </div>
@@ -182,7 +211,7 @@ export default function AdminApplicationDetailPage() {
 
   const dateLabel = useMemo(() => {
     if (!detail) return '-';
-    const date = parseDateLike(detail.updatedAt ?? detail.createdAt);
+    const date = parseDateLike(detail.createdAt ?? detail.updatedAt);
     return date ? formatYmd(date) : '-';
   }, [detail]);
 
@@ -210,7 +239,7 @@ export default function AdminApplicationDetailPage() {
 
     const ok = await confirm.open({
       title: '지원서 삭제',
-      description: `지원서(${detail.applicationId})를 삭제할까요?`,
+      description: '이 지원서를 삭제할까요?',
       danger: true,
       confirmText: '삭제',
     });
@@ -219,10 +248,10 @@ export default function AdminApplicationDetailPage() {
 
     try {
       await adminApplicationsApi.delete(String(detail.applicationId));
-      toast.success('삭제되었습니다.');
+      toast.success('지원서를 삭제했어요.');
       navigate(`/admin/applications?formId=${formId}`);
     } catch {
-      toast.error('삭제에 실패했습니다.');
+      toast.error('지원서를 삭제하지 못했어요.');
     }
   }, [confirm, detail, formId, navigate, toast]);
 
@@ -279,13 +308,12 @@ export default function AdminApplicationDetailPage() {
       >
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <p className="text-sm font-semibold text-slate-500">
-              #{detail.applicationId}
+            <p className="text-lg font-bold text-slate-900">
+              {detail.applicantName?.trim() || '이름 없음'}
             </p>
-            <p className="mt-1 text-lg font-bold text-slate-900">
-              {detail.studentId}
+            <p className="mt-1 text-xs text-slate-500">
+              학번 {detail.studentId} · 접수일 {dateLabel}
             </p>
-            <p className="mt-1 text-xs text-slate-500">{dateLabel}</p>
           </div>
 
           <div className="flex items-center gap-2">
@@ -319,6 +347,23 @@ export default function AdminApplicationDetailPage() {
         className="mt-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
       >
         <div className="space-y-6">
+          <section>
+            <h2 className="text-sm font-bold text-slate-700">기본 정보</h2>
+            <div className="mt-2 space-y-2 text-sm text-slate-600">
+              {(detail.basicAnswers ?? []).length === 0 ? (
+                <p>추가 기본 정보가 없습니다.</p>
+              ) : (
+                (detail.basicAnswers ?? []).map((ans) => (
+                  <AnswerCard
+                    key={`basic-${ans.formQuestionId}`}
+                    answer={ans}
+                    questionMap={questionMap}
+                  />
+                ))
+              )}
+            </div>
+          </section>
+
           <section>
             <h2 className="text-sm font-bold text-slate-700">공통 질문</h2>
             <div className="mt-2 space-y-2 text-sm text-slate-600">

--- a/src/pages/admin/AdminApplicationsListPage.tsx
+++ b/src/pages/admin/AdminApplicationsListPage.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
+import { Search, X } from 'lucide-react';
 import Reveal from '../../components/Reveal';
+import BackArrowIcon from '../../components/BackArrowIcon';
 import { useConfirm } from '../../components/confirm/useConfirm';
 import { useToast } from '../../components/toast/useToast';
 import {
@@ -24,6 +26,21 @@ const RESULT_OPTIONS: Array<{
 
 type SortOrder = 'desc' | 'asc';
 
+const RESULT_LABELS = RESULT_OPTIONS.reduce<
+  Partial<Record<AdminApplicationResultStatus, string>>
+>((acc, option) => {
+  if (option.value !== 'all') acc[option.value] = option.label;
+  return acc;
+}, {});
+
+function getFormStatusLabel(open: boolean) {
+  return open ? '현재 모집 중' : '비공개';
+}
+
+function getResultStatusLabel(status: AdminApplicationResultStatus) {
+  return RESULT_LABELS[status] ?? status;
+}
+
 export default function AdminApplicationsListPage() {
   const confirm = useConfirm();
   const toast = useToast();
@@ -42,6 +59,12 @@ export default function AdminApplicationsListPage() {
     'all' | AdminApplicationResultStatus
   >('all');
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
+  const selectedFormId = params.get('formId') ?? '';
+  const selectedForm = forms.find(
+    (form) => String(form.formId) === selectedFormId,
+  );
+  const selectedFormTitle = selectedForm?.title ?? '선택한 지원서';
+  const hasActiveFilter = query.trim() !== '' || resultFilter !== 'all';
 
   const load = useCallback(async (targetFormId: string) => {
     if (!targetFormId.trim()) {
@@ -96,6 +119,7 @@ export default function AdminApplicationsListPage() {
       if (!normalized) return true;
       return (
         item.studentId.toLowerCase().includes(normalized) ||
+        (item.applicantName ?? '').toLowerCase().includes(normalized) ||
         String(item.applicationId).includes(normalized)
       );
     });
@@ -123,7 +147,7 @@ export default function AdminApplicationsListPage() {
     async (item: AdminApplicationListItem) => {
       const ok = await confirm.open({
         title: '지원서 삭제',
-        description: `지원서(${item.applicationId})를 삭제할까요?`,
+        description: '이 지원서를 삭제할까요?',
         danger: true,
         confirmText: '삭제',
       });
@@ -131,11 +155,11 @@ export default function AdminApplicationsListPage() {
 
       try {
         await adminApplicationsApi.delete(String(item.applicationId));
-        toast.success('삭제되었습니다.');
+        toast.success('지원서를 삭제했어요.');
         const currentFormId = params.get('formId') ?? '';
         if (currentFormId) await load(currentFormId);
       } catch {
-        toast.error('삭제에 실패했습니다.');
+        toast.error('지원서를 삭제하지 못했어요.');
       }
     },
     [confirm, load, params, toast],
@@ -146,9 +170,20 @@ export default function AdminApplicationsListPage() {
       <Reveal>
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <h1 className="font-heading text-3xl text-primary">지원서 관리</h1>
+            <div className="mb-4">
+              <Link
+                to="/admin/forms"
+                className="inline-flex items-center gap-1.5 text-sm font-semibold text-slate-500 transition hover:text-slate-700"
+              >
+                <BackArrowIcon className="h-5 w-5" />
+                지원서 관리
+              </Link>
+            </div>
+            <h1 className="font-heading text-3xl text-primary">지원자 보기</h1>
             <p className="mt-2 text-sm text-slate-600">
-              '모집 양식을 선택하면 해당 지원서 목록을 조회할 수 있습니다.'
+              {selectedFormId
+                ? `${selectedFormTitle}에 제출한 지원자를 확인할 수 있어요`
+                : '지원서를 선택하면 지원자가 제출한 내용을 확인할 수 있어요'}
             </p>
           </div>
         </div>
@@ -156,50 +191,83 @@ export default function AdminApplicationsListPage() {
 
       <Reveal
         delayMs={120}
-        className="mt-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+        className="mt-6 rounded-3xl border border-slate-200 bg-white px-5 py-4 shadow-sm"
       >
-        <div className="flex flex-col gap-3 md:flex-row md:items-center">
-          {formsLoading ? (
-            <div className="w-full rounded-2xl border border-slate-200 px-4 py-2 text-sm text-slate-400 md:w-72">
-              양식 목록 불러오는 중...
-            </div>
-          ) : forms.length > 0 ? (
-            <select
-              value={formId}
-              onChange={(e) => setFormId(e.target.value)}
-              className="w-full rounded-2xl border border-slate-200 px-4 py-2 text-sm outline-none transition focus:border-primary/60 focus:ring-4 focus:ring-primary/10 md:w-72"
-            >
-              <option value="">양식 선택</option>
-              {forms.map((form) => (
-                <option key={form.formId} value={String(form.formId)}>
-                  [{form.open ? 'OPEN' : 'CLOSE'}] {form.title}
-                </option>
-              ))}
-            </select>
-          ) : (
-            <input
-              value={formId}
-              onChange={(e) => setFormId(e.target.value)}
-              placeholder="formId 입력"
-              className="w-full rounded-2xl border border-slate-200 px-4 py-2 text-sm outline-none transition focus:border-primary/60 focus:ring-4 focus:ring-primary/10 md:w-64"
-            />
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="text-sm font-bold text-slate-900">지원자 목록</p>
+            <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-bold text-primary">
+              {filtered.length > 0
+                ? `${filtered.length}명`
+                : hasActiveFilter
+                  ? '검색 결과 없음'
+                  : '지원자 없음'}
+            </span>
+            {list.length !== filtered.length && (
+              <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-500">
+                전체 {list.length}명
+              </span>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-end">
+          {!selectedFormId && (
+            <>
+              {formsLoading ? (
+                <div className="w-full rounded-2xl border border-slate-200 px-4 py-2.5 text-sm text-slate-400 lg:w-72">
+                  지원서 목록을 불러오는 중...
+                </div>
+              ) : forms.length > 0 ? (
+                <select
+                  value={formId}
+                  onChange={(e) => setFormId(e.target.value)}
+                  className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-2.5 text-sm outline-none transition focus:border-primary/60 focus:ring-4 focus:ring-primary/10 lg:w-72"
+                >
+                  <option value="">지원서 선택</option>
+                  {forms.map((form) => (
+                    <option key={form.formId} value={String(form.formId)}>
+                      [{getFormStatusLabel(form.open)}] {form.title}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  value={formId}
+                  onChange={(e) => setFormId(e.target.value)}
+                  placeholder="지원서 ID 입력"
+                  className="w-full rounded-2xl border border-slate-200 px-4 py-2.5 text-sm outline-none transition focus:border-primary/60 focus:ring-4 focus:ring-primary/10 lg:w-64"
+                />
+              )}
+
+              <button
+                type="button"
+                onClick={handleSearch}
+                className="rounded-xl bg-primary px-4 py-2.5 text-sm font-bold text-white transition hover:opacity-95"
+              >
+                조회
+              </button>
+            </>
           )}
 
-          <button
-            type="button"
-            onClick={handleSearch}
-            className="rounded-xl bg-primary px-4 py-2 text-sm font-bold text-white transition hover:opacity-95"
-          >
-            조회
-          </button>
-
-          <div className="flex w-full flex-col gap-2 md:flex-1 md:flex-row md:items-center md:justify-end">
-            <input
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="학번/지원서ID 검색"
-              className="w-full rounded-2xl border border-slate-200 px-4 py-2 text-sm outline-none transition focus:border-primary/60 focus:ring-4 focus:ring-primary/10 md:w-64"
-            />
+            <div className="relative w-full lg:w-72">
+              <Search className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+              <input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="이름/학번 검색"
+                className="w-full rounded-2xl border border-slate-200 py-2.5 pl-10 pr-10 text-sm outline-none transition focus:border-primary/60 focus:ring-4 focus:ring-primary/10"
+              />
+              {query && (
+                <button
+                  type="button"
+                  onClick={() => setQuery('')}
+                  className="absolute right-2.5 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-slate-400 transition hover:bg-slate-100 hover:text-slate-700"
+                  aria-label="검색어 지우기"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              )}
+            </div>
             <select
               value={resultFilter}
               onChange={(e) =>
@@ -207,7 +275,7 @@ export default function AdminApplicationsListPage() {
                   e.target.value as AdminApplicationResultStatus | 'all',
                 )
               }
-              className="rounded-2xl border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700"
+              className="rounded-2xl border border-slate-200 bg-white px-3 py-2.5 text-sm font-semibold text-slate-700"
             >
               {RESULT_OPTIONS.map((opt) => (
                 <option key={opt.value} value={opt.value}>
@@ -218,7 +286,7 @@ export default function AdminApplicationsListPage() {
             <select
               value={sortOrder}
               onChange={(e) => setSortOrder(e.target.value as SortOrder)}
-              className="rounded-2xl border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700"
+              className="rounded-2xl border border-slate-200 bg-white px-3 py-2.5 text-sm font-semibold text-slate-700"
             >
               <option value="desc">최신순</option>
               <option value="asc">오래된순</option>
@@ -244,27 +312,24 @@ export default function AdminApplicationsListPage() {
 
         <div className="divide-y divide-slate-100">
           {filtered.map((item) => {
-            const date = formatYmd(item.updatedAt ?? item.createdAt);
+            const date = formatYmd(item.createdAt ?? item.updatedAt);
+            const applicantName = item.applicantName?.trim() || '이름 없음';
             return (
-              <div
-                key={item.applicationId}
-                className="flex items-center gap-4 py-4"
-              >
-                <div className="w-24 text-xs font-semibold text-slate-500">
-                  #{item.applicationId}
-                </div>
+              <div key={item.applicationId} className="flex items-center gap-4 py-4">
                 <div className="flex-1">
                   <p className="text-sm font-bold text-slate-900">
-                    {item.studentId}
+                    {applicantName}
                   </p>
-                  <p className="mt-1 text-xs text-slate-500">{date}</p>
+                  <p className="mt-1 text-xs text-slate-500">
+                    학번 {item.studentId} · 접수일 {date}
+                  </p>
                   <p className="mt-1 text-xs text-slate-500">
                     1지망 {getDepartmentLabel(item.firstDepartment)} / 2지망{' '}
                     {getDepartmentLabel(item.secondDepartment)}
                   </p>
                 </div>
                 <span className="rounded-full bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-600">
-                  {item.resultStatus}
+                  {getResultStatusLabel(item.resultStatus)}
                 </span>
                 <div className="flex gap-2">
                   <Link

--- a/src/pages/admin/AdminFormDetailPage.tsx
+++ b/src/pages/admin/AdminFormDetailPage.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import Reveal from '../../components/Reveal';
+import BackArrowIcon from '../../components/BackArrowIcon';
 import { useConfirm } from '../../components/confirm/useConfirm';
 import { useToast } from '../../components/toast/useToast';
 import { ApiError } from '../../api/client';
@@ -16,7 +17,28 @@ import {
 import { DEPARTMENT_OPTIONS, getDepartmentLabel } from '../../types/recruit';
 
 const ANSWER_TYPES = ['TEXT', 'SELECT', 'FILE'] as const;
-const SECTION_TYPES = ['COMMON', 'DEPARTMENT'] as const;
+const ANSWER_TYPE_LABELS: Record<string, string> = {
+  TEXT: '주관식 답변',
+  SELECT: '선택형 답변',
+  FILE: '파일 업로드',
+};
+const SECTION_LABELS: Record<string, string> = {
+  BASIC: '기본 정보',
+  COMMON: '공통 질문',
+  DEPARTMENT: '부서별 질문',
+};
+const SYSTEM_BASIC_FIELDS = ['학번', '비밀번호', '1지망', '2지망'] as const;
+
+type AdminQuestionSection = {
+  key: string;
+  sectionType: string;
+  departmentType: string | null;
+  step: string;
+  title: string;
+  description: string;
+  questions: AdminFormQuestion[];
+  notices: AdminFormNoticeItem[];
+};
 
 const defaultQuestionPayload = (
   order: number,
@@ -37,6 +59,92 @@ const defaultNoticePayload: AdminFormNoticeCreateRequest = {
   title: '',
   content: '',
 };
+
+function isDepartmentSection(sectionType?: string | null) {
+  return (sectionType ?? '').toUpperCase() === 'DEPARTMENT';
+}
+
+function getSectionLabel(sectionType?: string | null) {
+  return SECTION_LABELS[(sectionType ?? '').toUpperCase()] ?? '추가 질문';
+}
+
+function getAnswerTypeLabel(answerType?: string | null) {
+  return ANSWER_TYPE_LABELS[(answerType ?? '').toUpperCase()] ?? '답변';
+}
+
+function normalizeSectionPayload<
+  T extends { sectionType: string; departmentType: string | null },
+>(payload: T): T {
+  return {
+    ...payload,
+    departmentType: isDepartmentSection(payload.sectionType)
+      ? payload.departmentType
+      : null,
+  };
+}
+
+function makeSectionKey(sectionType: string, departmentType?: string | null) {
+  return isDepartmentSection(sectionType)
+    ? `${sectionType}:${departmentType ?? 'NONE'}`
+    : sectionType;
+}
+
+function buildAdminQuestionSections(
+  questions: AdminFormQuestion[],
+  notices: AdminFormNoticeItem[],
+): AdminQuestionSection[] {
+  const baseSections: AdminQuestionSection[] = [
+    {
+      key: 'BASIC',
+      sectionType: 'BASIC',
+      departmentType: null,
+      step: '01',
+      title: '기본 정보',
+      description: '지원서 작성에 필요한 기본 항목을 확인합니다.',
+      questions: [],
+      notices: [],
+    },
+    {
+      key: 'COMMON',
+      sectionType: 'COMMON',
+      departmentType: null,
+      step: '02',
+      title: '공통 질문',
+      description: '모든 지원자에게 공통으로 노출되는 질문입니다.',
+      questions: [],
+      notices: [],
+    },
+    ...DEPARTMENT_OPTIONS.map((department, index) => ({
+      key: makeSectionKey('DEPARTMENT', department.value),
+      sectionType: 'DEPARTMENT',
+      departmentType: department.value,
+      step: String(index + 3).padStart(2, '0'),
+      title: `${department.label} 질문`,
+      description: `${department.label} 부서를 선택한 지원자에게 노출되는 질문입니다.`,
+      questions: [] as AdminFormQuestion[],
+      notices: [] as AdminFormNoticeItem[],
+    })),
+  ];
+
+  const sectionMap = new Map(baseSections.map((section) => [section.key, section]));
+
+  questions
+    .slice()
+    .sort((a, b) => a.questionOrder - b.questionOrder)
+    .forEach((question) => {
+      const key = makeSectionKey(question.sectionType, question.departmentType);
+      const section = sectionMap.get(key);
+      if (section) section.questions.push(question);
+    });
+
+  notices.forEach((notice) => {
+    const key = makeSectionKey(notice.sectionType, notice.departmentType);
+    const section = sectionMap.get(key);
+    if (section) section.notices.push(notice);
+  });
+
+  return baseSections;
+}
 
 export default function AdminFormDetailPage() {
   const { formId: rawFormId } = useParams<{ formId: string }>();
@@ -110,7 +218,7 @@ export default function AdminFormDetailPage() {
       setDetail(formData ?? null);
       setQuestions(Array.isArray(questionsData) ? questionsData : []);
     } catch {
-      setError('Form 정보를 불러오지 못했어요.');
+      setError('지원서 양식 정보를 불러오지 못했어요.');
     } finally {
       setLoading(false);
     }
@@ -142,7 +250,7 @@ export default function AdminFormDetailPage() {
       const created = await adminFormsApi.create({ title, open: createOpen });
       const id = created?.formId;
       if (id != null) {
-        toast.success('Form을 만들었어요.');
+        toast.success('지원서 양식을 만들었어요.');
         navigate(`/admin/forms/${id}`, { replace: true });
       }
     } catch {
@@ -158,7 +266,7 @@ export default function AdminFormDetailPage() {
       try {
         if (open) await adminFormsApi.open(formId);
         else await adminFormsApi.close(formId);
-        toast.success(open ? 'Form을 OPEN 했어요.' : 'Form을 CLOSE 했어요.');
+        toast.success(open ? '모집을 시작했어요.' : '모집을 종료했어요.');
         void loadDetail();
         void loadFormList();
       } catch {
@@ -172,9 +280,9 @@ export default function AdminFormDetailPage() {
     if (!formId || isNew) return;
 
     const ok = await confirm.open({
-      title: '폼 삭제',
+      title: '지원서 삭제',
       description:
-        '이 폼을 삭제할까요?\n활성 폼이거나 지원서가 존재하면 삭제되지 않을 수 있어요.',
+        '이 지원서를 삭제할까요?\n모집 중이거나 제출된 지원서가 있으면 삭제되지 않을 수 있어요.',
       danger: true,
       confirmText: '삭제',
     });
@@ -182,16 +290,16 @@ export default function AdminFormDetailPage() {
 
     try {
       await adminFormsApi.deleteForm(formId);
-      toast.success('폼을 삭제했어요.');
+      toast.success('지원서를 삭제했어요.');
       navigate('/admin/forms', { replace: true });
     } catch (e) {
       if (e instanceof ApiError && (e.status === 400 || e.status === 403)) {
-        toast.error('지원서가 존재하는 폼은 삭제할 수 없습니다.');
+        toast.error('제출된 지원서가 있으면 삭제할 수 없어요.');
       } else {
         toast.error(
           e instanceof Error
             ? e.message
-            : '폼 삭제에 실패했어요. 잠시 후 다시 시도해 주세요.',
+            : '지원서를 삭제하지 못했어요. 잠시 후 다시 시도해 주세요.',
         );
       }
     }
@@ -200,32 +308,33 @@ export default function AdminFormDetailPage() {
   const handleCopyQuestions = useCallback(async () => {
     const sourceId = copySourceId.trim();
     if (!sourceId || !formId || isNew) {
-      toast.error('복사할 Form을 선택해 주세요.');
+      toast.error('불러올 지원서를 선택해 주세요.');
       return;
     }
     const sourceNum = Number(sourceId);
     if (Number.isNaN(sourceNum) || sourceNum <= 0) {
-      toast.error('올바른 Form ID를 선택해 주세요.');
+      toast.error('올바른 지원서를 선택해 주세요.');
       return;
     }
     if (String(sourceNum) === formId) {
-      toast.error('같은 Form으로는 복사할 수 없어요.');
+      toast.error('같은 지원서에서는 불러올 수 없어요.');
       return;
     }
     const ok = await confirm.open({
-      title: '문항 복사',
-      description: `선택한 Form의 문항으로 덮어쓸까요? 현재 문항은 모두 삭제된 뒤 복사돼요.`,
+      title: '질문 불러오기',
+      description:
+        '선택한 지원서의 질문으로 덮어쓸까요? 현재 등록된 질문은 모두 삭제된 뒤 다시 불러와져요.',
       danger: true,
-      confirmText: '복사',
+      confirmText: '불러오기',
     });
     if (!ok) return;
     setCopying(true);
     try {
       await adminFormsApi.copyQuestions(formId, { sourceFormId: sourceNum });
-      toast.success('문항을 복사했어요.');
+      toast.success('질문을 불러왔어요.');
       void loadDetail();
     } catch {
-      toast.error('복사에 실패했어요.');
+      toast.error('질문을 불러오지 못했어요.');
     } finally {
       setCopying(false);
     }
@@ -235,29 +344,32 @@ export default function AdminFormDetailPage() {
     if (!formId || isNew) return;
     const label = addQuestionPayload.label.trim();
     if (!label) {
-      toast.error('문항 라벨을 입력해 주세요.');
+      toast.error('질문 제목을 입력해 주세요.');
       return;
     }
-    const payload = {
+    if (
+      isDepartmentSection(addQuestionPayload.sectionType) &&
+      !addQuestionPayload.departmentType
+    ) {
+      toast.error('부서별 질문은 부서를 선택해 주세요.');
+      return;
+    }
+    const payload = normalizeSectionPayload({
       ...addQuestionPayload,
-      departmentType:
-        addQuestionPayload.sectionType === 'COMMON'
-          ? null
-          : addQuestionPayload.departmentType,
       selectOptions:
         addQuestionPayload.answerType === 'SELECT'
           ? addQuestionPayload.selectOptions
           : null,
-    };
+    });
     setAddingQuestion(true);
     try {
       await adminFormsApi.addQuestion(formId, payload);
-      toast.success('문항을 추가했어요.');
+      toast.success('질문을 추가했어요.');
       setShowAddQuestion(false);
       setAddQuestionPayload(defaultQuestionPayload(questions.length + 1));
       void loadDetail();
     } catch {
-      toast.error('추가에 실패했어요.');
+      toast.error('질문을 추가하지 못했어요.');
     } finally {
       setAddingQuestion(false);
     }
@@ -266,17 +378,20 @@ export default function AdminFormDetailPage() {
   const handleUpdateQuestion = useCallback(
     async (formQuestionId: number) => {
       if (!formId || isNew || !editQuestionPayload) return;
-      const payload = {
+      if (
+        isDepartmentSection(editQuestionPayload.sectionType) &&
+        !editQuestionPayload.departmentType
+      ) {
+        toast.error('부서별 질문은 부서를 선택해 주세요.');
+        return;
+      }
+      const payload = normalizeSectionPayload({
         ...editQuestionPayload,
-        departmentType:
-          editQuestionPayload.sectionType === 'COMMON'
-            ? null
-            : editQuestionPayload.departmentType,
         selectOptions:
           editQuestionPayload.answerType === 'SELECT'
             ? editQuestionPayload.selectOptions
             : null,
-      };
+      });
       setUpdatingQuestion(true);
       try {
         await adminFormsApi.updateQuestion(
@@ -284,12 +399,12 @@ export default function AdminFormDetailPage() {
           String(formQuestionId),
           payload,
         );
-        toast.success('문항을 수정했어요.');
+        toast.success('질문을 수정했어요.');
         setEditingQuestionId(null);
         setEditQuestionPayload(null);
         void loadDetail();
       } catch {
-        toast.error('수정에 실패했어요.');
+        toast.error('질문을 수정하지 못했어요.');
       } finally {
         setUpdatingQuestion(false);
       }
@@ -301,18 +416,18 @@ export default function AdminFormDetailPage() {
     async (formQuestionId: number) => {
       if (!formId || isNew) return;
       const ok = await confirm.open({
-        title: '문항 삭제',
-        description: '이 문항을 삭제할까요?',
+        title: '질문 삭제',
+        description: '이 질문을 삭제할까요?',
         danger: true,
         confirmText: '삭제',
       });
       if (!ok) return;
       try {
         await adminFormsApi.deleteQuestion(formId, String(formQuestionId));
-        toast.success('삭제했어요.');
+        toast.success('질문을 삭제했어요.');
         void loadDetail();
       } catch {
-        toast.error('삭제에 실패했어요.');
+        toast.error('질문을 삭제하지 못했어요.');
       }
     },
     [confirm, formId, isNew, loadDetail, toast],
@@ -325,13 +440,14 @@ export default function AdminFormDetailPage() {
       toast.error('안내문 제목을 입력해 주세요.');
       return;
     }
-    const payload = {
-      ...addNoticePayload,
-      departmentType:
-        addNoticePayload.sectionType === 'COMMON'
-          ? null
-          : addNoticePayload.departmentType,
-    };
+    if (
+      isDepartmentSection(addNoticePayload.sectionType) &&
+      !addNoticePayload.departmentType
+    ) {
+      toast.error('부서별 안내문은 부서를 선택해 주세요.');
+      return;
+    }
+    const payload = normalizeSectionPayload(addNoticePayload);
     setAddingNotice(true);
     try {
       await adminFormsApi.addNotice(formId, payload);
@@ -340,7 +456,7 @@ export default function AdminFormDetailPage() {
       setAddNoticePayload(defaultNoticePayload);
       void loadDetail();
     } catch {
-      toast.error('추가에 실패했어요.');
+      toast.error('안내문을 추가하지 못했어요.');
     } finally {
       setAddingNotice(false);
     }
@@ -349,13 +465,14 @@ export default function AdminFormDetailPage() {
   const handleUpdateNotice = useCallback(
     async (noticeId: number) => {
       if (!formId || isNew || !editNoticePayload) return;
-      const payload = {
-        ...editNoticePayload,
-        departmentType:
-          editNoticePayload.sectionType === 'COMMON'
-            ? null
-            : editNoticePayload.departmentType,
-      };
+      if (
+        isDepartmentSection(editNoticePayload.sectionType) &&
+        !editNoticePayload.departmentType
+      ) {
+        toast.error('부서별 안내문은 부서를 선택해 주세요.');
+        return;
+      }
+      const payload = normalizeSectionPayload(editNoticePayload);
       setUpdatingNotice(true);
       try {
         await adminFormsApi.updateNotice(formId, String(noticeId), payload);
@@ -364,7 +481,7 @@ export default function AdminFormDetailPage() {
         setEditNoticePayload(null);
         void loadDetail();
       } catch {
-        toast.error('수정에 실패했어요.');
+        toast.error('안내문을 수정하지 못했어요.');
       } finally {
         setUpdatingNotice(false);
       }
@@ -384,16 +501,22 @@ export default function AdminFormDetailPage() {
       if (!ok) return;
       try {
         await adminFormsApi.deleteNotice(formId, String(noticeId));
-        toast.success('삭제했어요.');
+        toast.success('안내문을 삭제했어요.');
         void loadDetail();
       } catch {
-        toast.error('삭제에 실패했어요.');
+        toast.error('안내문을 삭제하지 못했어요.');
       }
     },
     [confirm, formId, isNew, loadDetail, toast],
   );
 
-  // ----- New Form create UI -----
+  const notices = useMemo(() => detail?.notices ?? [], [detail?.notices]);
+  const questionSections = useMemo(
+    () => buildAdminQuestionSections(questions, notices),
+    [notices, questions],
+  );
+
+  // ----- New form create UI -----
   if (isNew) {
     return (
       <div className="mx-auto max-w-6xl px-4 py-12">
@@ -401,12 +524,13 @@ export default function AdminFormDetailPage() {
           <div className="flex items-center gap-3">
             <Link
               to="/admin/forms"
-              className="rounded-lg border border-slate-200 px-3 py-1.5 text-sm font-semibold text-slate-600 hover:bg-slate-100"
+              className="inline-flex items-center gap-1.5 text-sm font-semibold text-slate-500 transition hover:text-slate-700"
             >
-              ← 목록
+              <BackArrowIcon className="h-5 w-5" />
+              지원서 관리
             </Link>
             <h1 className="font-heading text-3xl text-primary">
-              새 Form 만들기
+              새 지원서 양식 만들기
             </h1>
           </div>
         </Reveal>
@@ -417,29 +541,34 @@ export default function AdminFormDetailPage() {
           <div className="space-y-4">
             <div>
               <label className="block text-sm font-semibold text-slate-700">
-                제목
+                지원서 이름
               </label>
               <input
                 value={createTitle}
                 onChange={(e) => setCreateTitle(e.target.value)}
-                placeholder="예: 2026-1학기 모집"
+                placeholder="예: 명지공방 5기 지원서"
                 className="mt-1 w-full rounded-xl border border-slate-200 px-4 py-2 text-sm outline-none focus:border-primary/60 focus:ring-2 focus:ring-primary/20"
               />
             </div>
-            <div className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                id="create-open"
-                checked={createOpen}
-                onChange={(e) => setCreateOpen(e.target.checked)}
-                className="h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary"
-              />
-              <label
-                htmlFor="create-open"
+            <div className="rounded-2xl bg-slate-50 px-4 py-3">
+              <div className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  id="create-open"
+                  checked={createOpen}
+                  onChange={(e) => setCreateOpen(e.target.checked)}
+                  className="h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary"
+                />
+                <label
+                  htmlFor="create-open"
                 className="text-sm font-semibold text-slate-700"
               >
-                생성 후 OPEN 상태로 두기 (기존 OPEN Form은 자동 close)
+                이 지원서로 모집 시작하기
               </label>
+            </div>
+            <p className="mt-2 pl-6 text-xs leading-5 text-slate-500">
+                선택하면 지원자가 이 지원서를 작성할 수 있어요. 이미 모집 중인 지원서는 비공개로 전환돼요.
+            </p>
             </div>
             <div className="flex gap-2 pt-2">
               <button
@@ -478,19 +607,18 @@ export default function AdminFormDetailPage() {
         <div className="flex flex-wrap items-center gap-3">
           <Link
             to="/admin/forms"
-            className="rounded-lg border border-slate-200 px-3 py-1.5 text-sm font-semibold text-slate-600 hover:bg-slate-100"
+            className="inline-flex items-center gap-1.5 text-sm font-semibold text-slate-500 transition hover:text-slate-700"
           >
-            ← 목록
+            <BackArrowIcon className="h-5 w-5" />
+            지원서 관리
           </Link>
         </div>
         <p className="mt-4 text-sm font-semibold text-rose-600">
-          {error ?? 'Form을 찾을 수 없어요.'}
+          {error ?? '지원서 양식을 찾을 수 없어요.'}
         </p>
       </div>
     );
   }
-
-  const notices = detail.notices ?? [];
 
   return (
     <div className="mx-auto max-w-6xl px-4 py-12">
@@ -499,9 +627,10 @@ export default function AdminFormDetailPage() {
           <div className="flex flex-wrap items-center gap-3">
             <Link
               to="/admin/forms"
-              className="rounded-lg border border-slate-200 px-3 py-1.5 text-sm font-semibold text-slate-600 hover:bg-slate-100"
+              className="inline-flex items-center gap-1.5 text-sm font-semibold text-slate-500 transition hover:text-slate-700"
             >
-              ← 목록
+              <BackArrowIcon className="h-5 w-5" />
+              지원서 관리
             </Link>
             <h1 className="font-heading text-2xl text-primary md:text-3xl">
               {detail.title}
@@ -511,10 +640,10 @@ export default function AdminFormDetailPage() {
                 'rounded-full px-2 py-1 text-xs font-semibold',
                 detail.open
                   ? 'bg-emerald-100 text-emerald-700'
-                  : 'bg-slate-100 text-slate-500',
+                  : 'bg-rose-100 text-rose-700',
               ].join(' ')}
             >
-              {detail.open ? 'OPEN' : 'CLOSE'}
+              {detail.open ? '현재 모집 중' : '비공개'}
             </span>
           </div>
           <div className="flex flex-wrap gap-2">
@@ -524,7 +653,7 @@ export default function AdminFormDetailPage() {
                 onClick={() => void handleOpenClose(false)}
                 className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-bold text-amber-700 hover:bg-amber-100"
               >
-                Form CLOSE
+                모집 종료
               </button>
             ) : (
               <button
@@ -532,23 +661,16 @@ export default function AdminFormDetailPage() {
                 onClick={() => void handleOpenClose(true)}
                 className="rounded-xl bg-primary px-4 py-2 text-sm font-bold text-white transition hover:opacity-95"
               >
-                Form OPEN
+                이 지원서로 모집 시작
               </button>
             )}
-
-            <Link
-              to={`/admin/applications?formId=${detail.formId}`}
-              className="rounded-xl border border-slate-200 px-4 py-2 text-sm font-bold text-slate-700 hover:bg-slate-100"
-            >
-              지원서 보기
-            </Link>
 
             <button
               type="button"
               onClick={() => void handleDeleteForm()}
               className="rounded-xl border border-rose-200 px-4 py-2 text-sm font-bold text-rose-600 hover:bg-rose-50"
             >
-              폼 삭제
+              지원서 삭제
             </button>
           </div>
         </div>
@@ -558,11 +680,11 @@ export default function AdminFormDetailPage() {
       <Reveal delayMs={80} className="mt-6">
         <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
           <h2 className="text-sm font-bold text-slate-800">
-            문항 복사 (덮어쓰기)
+            질문 불러오기
           </h2>
           <p className="mt-1 text-xs text-slate-500">
-            다른 Form의 문항을 이 Form으로 가져옵니다. 현재 문항은 삭제된 뒤
-            복사돼요.
+            다른 지원서의 질문을 가져옵니다. 현재 등록된 질문은 삭제된 뒤
+            다시 불러와져요.
           </p>
           <div className="mt-3 flex flex-wrap items-center gap-2">
             <select
@@ -570,12 +692,12 @@ export default function AdminFormDetailPage() {
               onChange={(e) => setCopySourceId(e.target.value)}
               className="rounded-xl border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700"
             >
-              <option value="">Form 선택</option>
+              <option value="">불러올 지원서 선택</option>
               {formList
                 .filter((f) => String(f.formId) !== formId)
                 .map((f) => (
                   <option key={f.formId} value={f.formId}>
-                    {f.title} (ID: {f.formId})
+                    {f.title}
                   </option>
                 ))}
             </select>
@@ -585,182 +707,277 @@ export default function AdminFormDetailPage() {
               disabled={copying || !copySourceId}
               className="rounded-xl border border-slate-200 px-4 py-2 text-sm font-bold text-slate-700 hover:bg-slate-100 disabled:opacity-50"
             >
-              {copying ? '복사 중...' : '복사'}
+              {copying ? '불러오는 중...' : '불러오기'}
             </button>
           </div>
         </div>
       </Reveal>
 
-      {/* Questions */}
+      {/* Sections */}
       <Reveal delayMs={120} className="mt-6">
         <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <h2 className="text-lg font-bold text-slate-800">문항</h2>
-            <button
-              type="button"
-              onClick={() => {
-                setShowAddQuestion((v) => !v);
-                if (!showAddQuestion)
-                  setAddQuestionPayload(
-                    defaultQuestionPayload(questions.length + 1),
-                  );
-              }}
-              className="rounded-lg border border-primary/30 bg-primary/10 px-3 py-1.5 text-sm font-bold text-primary hover:bg-primary/20"
-            >
-              {showAddQuestion ? '취소' : '문항 추가'}
-            </button>
+          <div>
+            <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">
+              Application Sections
+            </p>
+            <h2 className="mt-2 text-lg font-bold text-slate-900">
+              지원서 섹션 구성
+            </h2>
+            <p className="mt-1 text-sm leading-6 text-slate-500">
+              사용자 지원서 화면과 같은 기준으로 질문과 안내문을 섹션별로
+              관리합니다.
+            </p>
           </div>
 
-          {showAddQuestion && (
-            <QuestionForm
-              payload={addQuestionPayload}
-              setPayload={setAddQuestionPayload}
-              onSubmit={() => void handleAddQuestion()}
-              submitting={addingQuestion}
-              submitLabel="추가"
-            />
-          )}
+          <div className="mt-5 space-y-4">
+            {questionSections.map((section) => {
+              const sectionKey = makeSectionKey(
+                section.sectionType,
+                section.departmentType,
+              );
+              const addingQuestionHere =
+                showAddQuestion &&
+                makeSectionKey(
+                  addQuestionPayload.sectionType,
+                  addQuestionPayload.departmentType,
+                ) === sectionKey;
+              const addingNoticeHere =
+                showAddNotice &&
+                makeSectionKey(
+                  addNoticePayload.sectionType,
+                  addNoticePayload.departmentType,
+                ) === sectionKey;
 
-          <div className="mt-4 space-y-3">
-            {questions.length === 0 && !showAddQuestion && (
-              <p className="py-4 text-center text-sm text-slate-500">
-                문항이 없어요. 문항 추가로 넣어 주세요.
-              </p>
-            )}
-            {questions.map((q) => (
-              <div
-                key={q.formQuestionId}
-                className="rounded-xl border border-slate-100 bg-slate-50/50 p-4"
-              >
-                {editingQuestionId === q.formQuestionId &&
-                editQuestionPayload ? (
-                  <QuestionForm
-                    payload={editQuestionPayload}
-                    setPayload={setEditQuestionPayload}
-                    onSubmit={() => void handleUpdateQuestion(q.formQuestionId)}
-                    onCancel={() => {
-                      setEditingQuestionId(null);
-                      setEditQuestionPayload(null);
-                    }}
-                    submitting={updatingQuestion}
-                    submitLabel="저장"
-                  />
-                ) : (
-                  <>
-                    <div className="flex flex-wrap items-start justify-between gap-2">
-                      <div>
-                        <span className="text-xs font-semibold text-slate-500">
-                          #{q.questionOrder}
-                        </span>
-                        <p className="font-semibold text-slate-900">
-                          {q.label}
-                        </p>
-                        {q.description && (
-                          <p className="mt-1 text-sm text-slate-600">
-                            {q.description}
-                          </p>
-                        )}
-                        <p className="mt-1 text-xs text-slate-500">
-                          {q.answerType} · {q.required ? '필수' : '선택'}
-                        </p>
-                      </div>
-                      <div className="flex gap-2">
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setEditingQuestionId(q.formQuestionId);
-                            setEditQuestionPayload({
-                              label: q.label,
-                              description: q.description,
-                              questionOrder: q.questionOrder,
-                              required: q.required,
-                              answerType: q.answerType,
-                              selectOptions: q.selectOptions || null,
-                              sectionType: q.sectionType,
-                              departmentType: q.departmentType,
+              return (
+                <section
+                  key={section.key}
+                  className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="text-xs font-black text-primary">
+                        {section.step}
+                      </p>
+                      <h3 className="mt-1 text-base font-bold text-slate-950">
+                        {section.title}
+                      </h3>
+                      <p className="mt-1 text-sm leading-6 text-slate-500">
+                        {section.description}
+                      </p>
+                      {section.sectionType === 'BASIC' && (
+                        <div className="mt-3 flex flex-wrap gap-2">
+                          {SYSTEM_BASIC_FIELDS.map((field) => (
+                            <span
+                              key={field}
+                              className="rounded-full border border-primary/15 bg-primary/5 px-3 py-1 text-xs font-bold text-primary"
+                            >
+                              {field}
+                            </span>
+                          ))}
+                          <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-500">
+                            사용자 화면에서 자동 제공
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const nextPayload = {
+                            ...defaultQuestionPayload(questions.length + 1),
+                            sectionType: section.sectionType,
+                            departmentType: section.departmentType,
+                          };
+                          const nextKey = makeSectionKey(
+                            nextPayload.sectionType,
+                            nextPayload.departmentType,
+                          );
+                          setShowAddNotice(false);
+                          setShowAddQuestion(
+                            !(showAddQuestion && nextKey === sectionKey),
+                          );
+                          setAddQuestionPayload(nextPayload);
+                        }}
+                        className="rounded-lg border border-primary/30 bg-white px-3 py-1.5 text-xs font-bold text-primary hover:bg-primary/10"
+                      >
+                        {addingQuestionHere ? '추가 취소' : '질문 추가'}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const nextPayload = {
+                            ...defaultNoticePayload,
+                            sectionType: section.sectionType,
+                            departmentType: section.departmentType,
+                          };
+                          const nextKey = makeSectionKey(
+                            nextPayload.sectionType,
+                            nextPayload.departmentType,
+                          );
+                          setShowAddQuestion(false);
+                          setShowAddNotice(
+                            !(showAddNotice && nextKey === sectionKey),
+                          );
+                          setAddNoticePayload(nextPayload);
+                        }}
+                        className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-bold text-slate-700 hover:bg-slate-100"
+                      >
+                        {addingNoticeHere ? '추가 취소' : '안내문 추가'}
+                      </button>
+                    </div>
+                  </div>
+
+                  {addingQuestionHere && (
+                    <QuestionForm
+                      payload={addQuestionPayload}
+                      setPayload={setAddQuestionPayload}
+                      onSubmit={() => void handleAddQuestion()}
+                      submitting={addingQuestion}
+                      submitLabel="추가"
+                    />
+                  )}
+
+                  {addingNoticeHere && (
+                    <NoticeForm
+                      payload={addNoticePayload}
+                      setPayload={setAddNoticePayload}
+                      onSubmit={() => void handleAddNotice()}
+                      submitting={addingNotice}
+                      submitLabel="추가"
+                    />
+                  )}
+
+                  {section.notices.length > 0 && (
+                    <div className="mt-4 space-y-2">
+                      <p className="text-xs font-bold text-slate-400">안내문</p>
+                      {section.notices.map((n) => (
+                        <NoticeRow
+                          key={n.noticeId}
+                          notice={n}
+                          editing={editingNoticeId === n.noticeId}
+                          editPayload={editNoticePayload}
+                          setEditPayload={setEditNoticePayload}
+                          onStartEdit={() => {
+                            setEditingNoticeId(n.noticeId);
+                            setShowAddQuestion(false);
+                            setShowAddNotice(false);
+                            setEditNoticePayload({
+                              sectionType: n.sectionType,
+                              departmentType: n.departmentType ?? null,
+                              title: n.title,
+                              content: n.content,
                             });
                           }}
-                          className="rounded-lg border border-slate-200 px-2 py-1 text-xs font-bold text-slate-700 hover:bg-slate-100"
-                        >
-                          수정
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() =>
-                            void handleDeleteQuestion(q.formQuestionId)
-                          }
-                          className="rounded-lg border border-rose-200 px-2 py-1 text-xs font-bold text-rose-600 hover:bg-rose-50"
-                        >
-                          삭제
-                        </button>
-                      </div>
+                          onSave={() => void handleUpdateNotice(n.noticeId)}
+                          onCancel={() => {
+                            setEditingNoticeId(null);
+                            setEditNoticePayload(null);
+                          }}
+                          onDelete={() => void handleDeleteNotice(n.noticeId)}
+                          updating={updatingNotice}
+                        />
+                      ))}
                     </div>
-                  </>
-                )}
-              </div>
-            ))}
-          </div>
-        </div>
-      </Reveal>
+                  )}
 
-      {/* Notices */}
-      <Reveal delayMs={160} className="mt-6">
-        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <h2 className="text-lg font-bold text-slate-800">안내문</h2>
-            <button
-              type="button"
-              onClick={() => {
-                setShowAddNotice((v) => !v);
-                if (!showAddNotice) setAddNoticePayload(defaultNoticePayload);
-              }}
-              className="rounded-lg border border-primary/30 bg-primary/10 px-3 py-1.5 text-sm font-bold text-primary hover:bg-primary/20"
-            >
-              {showAddNotice ? '취소' : '안내문 추가'}
-            </button>
-          </div>
-
-          {showAddNotice && (
-            <NoticeForm
-              payload={addNoticePayload}
-              setPayload={setAddNoticePayload}
-              onSubmit={() => void handleAddNotice()}
-              submitting={addingNotice}
-              submitLabel="추가"
-            />
-          )}
-
-          <div className="mt-4 space-y-3">
-            {notices.length === 0 && !showAddNotice && (
-              <p className="py-4 text-center text-sm text-slate-500">
-                안내문이 없어요.
-              </p>
-            )}
-            {notices.map((n) => (
-              <NoticeRow
-                key={n.noticeId}
-                notice={n}
-                editing={editingNoticeId === n.noticeId}
-                editPayload={editNoticePayload}
-                setEditPayload={setEditNoticePayload}
-                onStartEdit={() => {
-                  setEditingNoticeId(n.noticeId);
-                  setEditNoticePayload({
-                    sectionType: n.sectionType,
-                    departmentType: n.departmentType ?? null,
-                    title: n.title,
-                    content: n.content,
-                  });
-                }}
-                onSave={() => void handleUpdateNotice(n.noticeId)}
-                onCancel={() => {
-                  setEditingNoticeId(null);
-                  setEditNoticePayload(null);
-                }}
-                onDelete={() => void handleDeleteNotice(n.noticeId)}
-                updating={updatingNotice}
-              />
-            ))}
+                  <div className="mt-4 space-y-3">
+                    {section.questions.length === 0 &&
+                      section.notices.length === 0 &&
+                      section.sectionType !== 'BASIC' && (
+                      <p className="rounded-xl border border-dashed border-slate-200 bg-white px-4 py-5 text-center text-sm text-slate-500">
+                        아직 등록된 질문이나 안내문이 없어요.
+                      </p>
+                    )}
+                    {section.questions.length === 0 &&
+                      section.sectionType === 'BASIC' && (
+                        <p className="rounded-xl border border-dashed border-primary/20 bg-white px-4 py-4 text-sm leading-6 text-slate-500">
+                          학번, 비밀번호, 지원 부서는 기본 항목으로 자동
+                          제공돼요. 별도로 받고 싶은 정보가 있을 때만 질문을
+                          추가해 주세요.
+                        </p>
+                      )}
+                    {section.questions.map((q) => (
+                      <div
+                        key={q.formQuestionId}
+                        className="rounded-xl border border-slate-100 bg-white p-4"
+                      >
+                        {editingQuestionId === q.formQuestionId &&
+                        editQuestionPayload ? (
+                          <QuestionForm
+                            payload={editQuestionPayload}
+                            setPayload={setEditQuestionPayload}
+                            onSubmit={() =>
+                              void handleUpdateQuestion(q.formQuestionId)
+                            }
+                            onCancel={() => {
+                              setEditingQuestionId(null);
+                              setEditQuestionPayload(null);
+                            }}
+                            submitting={updatingQuestion}
+                            submitLabel="저장"
+                          />
+                        ) : (
+                          <>
+                            <div className="flex flex-wrap items-start justify-between gap-2">
+                              <div>
+                                <span className="text-xs font-semibold text-slate-500">
+                                  #{q.questionOrder}
+                                </span>
+                                <p className="font-semibold text-slate-900">
+                                  {q.label}
+                                </p>
+                                {q.description && (
+                                  <p className="mt-1 text-sm text-slate-600">
+                                    {q.description}
+                                  </p>
+                                )}
+                                <p className="mt-1 text-xs text-slate-500">
+                                  {getAnswerTypeLabel(q.answerType)} ·{' '}
+                                  {q.required ? '필수' : '선택'}
+                                </p>
+                              </div>
+                              <div className="flex gap-2">
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    setEditingQuestionId(q.formQuestionId);
+                                    setShowAddQuestion(false);
+                                    setShowAddNotice(false);
+                                    setEditQuestionPayload({
+                                      label: q.label,
+                                      description: q.description,
+                                      questionOrder: q.questionOrder,
+                                      required: q.required,
+                                      answerType: q.answerType,
+                                      selectOptions: q.selectOptions || null,
+                                      sectionType: q.sectionType,
+                                      departmentType: q.departmentType,
+                                    });
+                                  }}
+                                  className="rounded-lg border border-slate-200 px-2 py-1 text-xs font-bold text-slate-700 hover:bg-slate-100"
+                                >
+                                  수정
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    void handleDeleteQuestion(q.formQuestionId)
+                                  }
+                                  className="rounded-lg border border-rose-200 px-2 py-1 text-xs font-bold text-rose-600 hover:bg-rose-50"
+                                >
+                                  삭제
+                                </button>
+                              </div>
+                            </div>
+                          </>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              );
+            })}
           </div>
         </div>
       </Reveal>
@@ -788,17 +1005,18 @@ function QuestionForm({
       <div className="grid gap-2 sm:grid-cols-2">
         <div>
           <label className="block text-xs font-semibold text-slate-600">
-            라벨
+            질문 제목
           </label>
           <input
             value={payload.label}
             onChange={(e) => setPayload({ ...payload, label: e.target.value })}
+            placeholder="예: 명지공방에 지원하게 된 이유를 알려주세요."
             className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-1.5 text-sm"
           />
         </div>
         <div>
           <label className="block text-xs font-semibold text-slate-600">
-            순서
+            표시 순서
           </label>
           <input
             type="number"
@@ -810,19 +1028,21 @@ function QuestionForm({
                 questionOrder: Number(e.target.value) || 1,
               })
             }
+              placeholder="예: 1"
             className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-1.5 text-sm"
           />
         </div>
       </div>
       <div>
         <label className="block text-xs font-semibold text-slate-600">
-          설명
+          질문 설명
         </label>
         <input
           value={payload.description}
           onChange={(e) =>
             setPayload({ ...payload, description: e.target.value })
           }
+          placeholder="예: 해보고 싶은 활동이나 기대하는 경험을 함께 적어주세요."
           className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-1.5 text-sm"
         />
       </div>
@@ -840,7 +1060,7 @@ function QuestionForm({
         </label>
         <div className="flex items-center gap-2">
           <span className="text-xs font-semibold text-slate-600">
-            답변 타입
+            답변 방식
           </span>
           <select
             value={payload.answerType}
@@ -856,7 +1076,7 @@ function QuestionForm({
           >
             {ANSWER_TYPES.map((t) => (
               <option key={t} value={t}>
-                {t}
+                {getAnswerTypeLabel(t)}
               </option>
             ))}
           </select>
@@ -871,50 +1091,10 @@ function QuestionForm({
                   selectOptions: e.target.value || null,
                 })
               }
-              placeholder="선택 옵션 (쉼표 등)"
+              placeholder="예: 카드뉴스, 포스터, 굿즈, 영상"
               className="w-full rounded-lg border border-slate-200 px-3 py-1.5 text-sm"
             />
           </div>
-        )}
-      </div>
-      <div className="flex items-center gap-2">
-        <span className="text-xs font-semibold text-slate-600">섹션</span>
-        <select
-          value={payload.sectionType}
-          onChange={(e) =>
-            setPayload({
-              ...payload,
-              sectionType: e.target.value,
-              departmentType:
-                e.target.value === 'COMMON' ? null : payload.departmentType,
-            })
-          }
-          className="rounded-lg border border-slate-200 px-2 py-1 text-sm"
-        >
-          {SECTION_TYPES.map((t) => (
-            <option key={t} value={t}>
-              {t}
-            </option>
-          ))}
-        </select>
-        {payload.sectionType !== 'COMMON' && (
-          <select
-            value={payload.departmentType ?? ''}
-            onChange={(e) =>
-              setPayload({
-                ...payload,
-                departmentType: e.target.value || null,
-              })
-            }
-            className="rounded-lg border border-slate-200 px-2 py-1 text-sm"
-          >
-            <option value="">부서 선택</option>
-            {DEPARTMENT_OPTIONS.map(({ value, label }) => (
-              <option key={value} value={value}>
-                {label}
-              </option>
-            ))}
-          </select>
         )}
       </div>
       <div className="flex gap-2 pt-2">
@@ -955,66 +1135,26 @@ function NoticeForm({
 }) {
   return (
     <div className="mt-4 space-y-3 rounded-xl border border-slate-200 bg-slate-50/80 p-4">
-      <div className="flex flex-wrap gap-3">
-        <div className="flex items-center gap-2">
-          <span className="text-xs font-semibold text-slate-600">섹션</span>
-          <select
-            value={payload.sectionType}
-            onChange={(e) =>
-              setPayload({
-                ...payload,
-                sectionType: e.target.value,
-                departmentType:
-                  e.target.value === 'COMMON' ? null : payload.departmentType,
-              })
-            }
-            className="rounded-lg border border-slate-200 px-2 py-1 text-sm"
-          >
-            {SECTION_TYPES.map((t) => (
-              <option key={t} value={t}>
-                {t}
-              </option>
-            ))}
-          </select>
-        </div>
-        {payload.sectionType !== 'COMMON' && (
-          <select
-            value={payload.departmentType ?? ''}
-            onChange={(e) =>
-              setPayload({
-                ...payload,
-                departmentType: e.target.value || null,
-              })
-            }
-            className="rounded-lg border border-slate-200 px-2 py-1 text-sm"
-          >
-            <option value="">부서</option>
-            {DEPARTMENT_OPTIONS.map(({ value, label }) => (
-              <option key={value} value={value}>
-                {label}
-              </option>
-            ))}
-          </select>
-        )}
-      </div>
       <div>
         <label className="block text-xs font-semibold text-slate-600">
-          제목
+          안내 제목
         </label>
         <input
           value={payload.title}
           onChange={(e) => setPayload({ ...payload, title: e.target.value })}
+          placeholder="예: 포트폴리오 제출 안내"
           className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-1.5 text-sm"
         />
       </div>
       <div>
         <label className="block text-xs font-semibold text-slate-600">
-          내용
+          안내 내용
         </label>
         <textarea
           value={payload.content}
           onChange={(e) => setPayload({ ...payload, content: e.target.value })}
           rows={3}
+          placeholder="예: 디자인 지원자는 포트폴리오 파일이나 링크를 함께 제출해 주세요."
           className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-1.5 text-sm"
         />
       </div>
@@ -1076,7 +1216,7 @@ function NoticeRow({
       <div>
         <p className="font-semibold text-slate-900">{notice.title}</p>
         <p className="mt-1 text-xs text-slate-500">
-          {notice.sectionType}
+          {getSectionLabel(notice.sectionType)}
           {notice.departmentType
             ? ` · ${getDepartmentLabel(notice.departmentType)}`
             : ''}

--- a/src/pages/admin/AdminFormDetailPage.tsx
+++ b/src/pages/admin/AdminFormDetailPage.tsx
@@ -897,7 +897,7 @@ export default function AdminFormDetailPage() {
                           추가해 주세요.
                         </p>
                       )}
-                    {section.questions.map((q) => (
+                    {section.questions.map((q, questionIndex) => (
                       <div
                         key={q.formQuestionId}
                         className="rounded-xl border border-slate-100 bg-white p-4"
@@ -922,7 +922,7 @@ export default function AdminFormDetailPage() {
                             <div className="flex flex-wrap items-start justify-between gap-2">
                               <div>
                                 <span className="text-xs font-semibold text-slate-500">
-                                  #{q.questionOrder}
+                                  #{questionIndex + 1}
                                 </span>
                                 <p className="font-semibold text-slate-900">
                                   {q.label}

--- a/src/pages/admin/AdminFormsListPage.tsx
+++ b/src/pages/admin/AdminFormsListPage.tsx
@@ -3,10 +3,12 @@ import { Link, useNavigate } from 'react-router-dom';
 import Reveal from '../../components/Reveal';
 import { adminFormsApi, type AdminFormListItem } from '../../api/adminForms';
 import { ApiError } from '../../api/client';
+import { useConfirm } from '../../components/confirm/useConfirm';
 import { useToast } from '../../components/toast/useToast';
 
 export default function AdminFormsListPage() {
   const navigate = useNavigate();
+  const confirm = useConfirm();
   const toast = useToast();
 
   const [list, setList] = useState<AdminFormListItem[]>([]);
@@ -22,7 +24,7 @@ export default function AdminFormsListPage() {
       setList(Array.isArray(data) ? data : []);
     } catch {
       setError(
-        '모집 Form 목록을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.',
+        '지원서 목록을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.',
       );
     } finally {
       setLoading(false);
@@ -34,9 +36,12 @@ export default function AdminFormsListPage() {
   }, [load]);
 
   const handleDeleteForm = async (form: AdminFormListItem) => {
-    const ok = window.confirm(
-      `"${form.title}" 폼을 삭제할까요?\n활성 폼이거나 지원서가 있으면 삭제할 수 없습니다.`,
-    );
+    const ok = await confirm.open({
+      title: '지원서 삭제',
+      description: `${form.title} 지원서를 삭제할까요?\n모집 중이거나 제출된 지원서가 있으면 삭제할 수 없어요.`,
+      danger: true,
+      confirmText: '삭제',
+    });
     if (!ok) return;
 
     setDeletingFormId(form.formId);
@@ -44,15 +49,15 @@ export default function AdminFormsListPage() {
     try {
       await adminFormsApi.deleteForm(String(form.formId));
       setList((prev) => prev.filter((x) => x.formId !== form.formId));
-      toast.success('폼을 삭제했어요.');
+      toast.success('지원서를 삭제했어요.');
     } catch (e) {
       if (e instanceof ApiError && (e.status === 400 || e.status === 403)) {
-        toast.error('지원서가 존재하는 폼은 삭제할 수 없습니다.');
+        toast.error('제출된 지원서가 있는 항목은 삭제할 수 없어요.');
       } else {
         toast.error(
           e instanceof Error
             ? e.message
-            : '폼 삭제에 실패했어요. 잠시 후 다시 시도해 주세요.',
+            : '지원서를 삭제하지 못했어요. 잠시 후 다시 시도해 주세요.',
         );
       }
     } finally {
@@ -66,10 +71,10 @@ export default function AdminFormsListPage() {
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <h1 className="font-heading text-3xl text-primary">
-              모집 Form 관리
+              지원서 관리
             </h1>
             <p className="mt-2 text-sm text-slate-600">
-              모집 Form을 만들고 문항/안내문을 설정할 수 있어요.
+              지원서를 만들고, 지원자가 제출한 내용을 확인할 수 있어요
             </p>
           </div>
           <button
@@ -77,7 +82,7 @@ export default function AdminFormsListPage() {
             onClick={() => navigate('/admin/forms/new')}
             className="rounded-xl bg-primary px-4 py-2 text-sm font-bold text-white transition hover:opacity-95"
           >
-            + Form 만들기
+            + 지원서 만들기
           </button>
         </div>
       </Reveal>
@@ -98,16 +103,16 @@ export default function AdminFormsListPage() {
 
         {!loading && !error && list.length === 0 && (
           <div className="py-12 text-center text-sm text-slate-500">
-            <p className="font-semibold">아직 등록된 모집 Form이 없어요.</p>
+            <p className="font-semibold">아직 등록된 지원서가 없어요.</p>
             <p className="mt-2 text-xs text-slate-400">
-              오른쪽 상단의 + Form 만들기 버튼으로 추가해 주세요.
+              오른쪽 상단의 + 지원서 만들기 버튼으로 추가해 주세요.
             </p>
             <button
               type="button"
               onClick={() => navigate('/admin/forms/new')}
               className="mt-4 rounded-xl bg-primary px-4 py-2 text-sm font-bold text-white transition hover:opacity-95"
             >
-              + Form 만들기
+              + 지원서 만들기
             </button>
           </div>
         )}
@@ -131,10 +136,10 @@ export default function AdminFormsListPage() {
                         'rounded-full px-2 py-1 text-xs font-semibold',
                         form.open
                           ? 'bg-emerald-100 text-emerald-700'
-                          : 'bg-slate-100 text-slate-500',
+                          : 'bg-rose-100 text-rose-700',
                       ].join(' ')}
                     >
-                      {form.open ? 'OPEN' : 'CLOSE'}
+                      {form.open ? '현재 모집 중' : '비공개'}
                     </span>
                   </div>
 
@@ -143,13 +148,13 @@ export default function AdminFormsListPage() {
                       to={`/admin/applications?formId=${form.formId}`}
                       className="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-bold text-slate-700 hover:bg-slate-100"
                     >
-                      지원서
+                      지원자 보기
                     </Link>
                     <Link
                       to={`/admin/forms/${form.formId}`}
-                      className="rounded-lg border border-primary/30 bg-primary/10 px-3 py-1.5 text-xs font-bold text-primary hover:bg-primary/20"
+                      className="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-bold text-slate-700 hover:bg-slate-100"
                     >
-                      문항·안내문 관리
+                      지원서 관리
                     </Link>
                     <button
                       type="button"

--- a/src/pages/admin/sections/AdminIntroduceMainEditor.tsx
+++ b/src/pages/admin/sections/AdminIntroduceMainEditor.tsx
@@ -18,6 +18,16 @@ type AdminIntroduceMainEditorState = {
   heroLogos: HeroLogoItem[];
 };
 
+type AdminIntroduceMainResponse = {
+  title?: string | null;
+  subtitle?: string | null;
+  summary?: string | null;
+  heroLogos?: Array<{
+    key?: string | null;
+    imageUrl?: string | null;
+  }> | null;
+} | null;
+
 const DEFAULT_MAIN: AdminIntroduceMainEditorState = {
   title: '',
   subtitle: '',
@@ -47,7 +57,9 @@ async function uploadToS3(uploadUrl: string, file: File, contentType: string) {
   if (!response.ok) throw new Error('S3 업로드에 실패했습니다.');
 }
 
-function normalizeMain(payload: any): AdminIntroduceMainEditorState {
+function normalizeMain(
+  payload: AdminIntroduceMainResponse,
+): AdminIntroduceMainEditorState {
   if (!payload) return DEFAULT_MAIN;
 
   return {
@@ -56,7 +68,7 @@ function normalizeMain(payload: any): AdminIntroduceMainEditorState {
     summary: payload.summary ?? '',
     heroLogos: Array.isArray(payload.heroLogos)
       ? payload.heroLogos
-          .map((l: any) => ({
+          .map((l) => ({
             key: (l.key ?? '').trim(),
             imageUrl: l.imageUrl ?? undefined,
           }))

--- a/src/pages/site/NoticesPage.tsx
+++ b/src/pages/site/NoticesPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import Reveal from '../../components/Reveal';
@@ -90,12 +90,8 @@ export default function NoticesPage() {
     queryFn: () => noticesApi.list(),
   });
 
-  const notices: NoticeResponse[] = data ?? [];
+  const notices = useMemo<NoticeResponse[]>(() => data ?? [], [data]);
   const error = isError ? '공지사항을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.' : null;
-
-  useEffect(() => {
-    setPage(1);
-  }, [query, imageFilter, sortOrder]);
 
   const filtered = useMemo(() => {
     const normalized = query.trim().toLowerCase();
@@ -182,7 +178,10 @@ export default function NoticesPage() {
           {/* 검색: 모바일에서는 한 줄, 데스크톱에서는 한 줄 */}
           <input
             value={query}
-            onChange={(e) => setQuery(e.target.value)}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setPage(1);
+            }}
             placeholder="제목/내용 검색"
             className="w-full rounded-2xl border border-slate-200 px-4 py-2 text-sm outline-none transition focus:border-primary/60 focus:ring-4 focus:ring-primary/10 md:flex-1"
           />
@@ -191,7 +190,10 @@ export default function NoticesPage() {
           <div className="flex w-full items-center gap-2 md:w-auto">
             <select
               value={imageFilter}
-              onChange={(e) => setImageFilter(e.target.value as ImageFilter)}
+              onChange={(e) => {
+                setImageFilter(e.target.value as ImageFilter);
+                setPage(1);
+              }}
               className="flex-1 rounded-2xl border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 md:flex-none md:min-w-[120px]"
             >
               {FILTER_OPTIONS.map((option) => (
@@ -203,7 +205,10 @@ export default function NoticesPage() {
 
             <select
               value={sortOrder}
-              onChange={(e) => setSortOrder(e.target.value as SortOrder)}
+              onChange={(e) => {
+                setSortOrder(e.target.value as SortOrder);
+                setPage(1);
+              }}
               className="flex-1 rounded-2xl border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 md:flex-none md:min-w-[120px]"
             >
               {SORT_OPTIONS.map((option) => (

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -32,6 +32,10 @@ export function formatYmd(value: DateLike): string {
     if (!y || !m || !d) return '-';
     return `${String(y).padStart(4, '0')}-${String(m).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
   }
-  if (typeof value === 'string') return value.trim() || '-';
+  if (typeof value === 'string') {
+    const date = parseDateLike(value);
+    if (date) return formatYmd(date);
+    return value.trim() || '-';
+  }
   return '-';
 }


### PR DESCRIPTION
## Summary

- 관리자 네비게이션과 지원서 관리 목록 화면의 문구/상태 표시를 정리했습니다.
- 지원서 질문을 기본 정보, 공통 질문, 부서별 질문 섹션으로 관리할 수 있도록 화면을 개편했습니다.
- 지원자 목록/상세 화면에서 이름, 학번, 접수일, 파일 미리보기/다운로드 표시를 개선했습니다.
- 질문 표시 번호를 저장된 순서값이 아닌 화면에 보이는 연속 번호로 표시하도록 변경했습니다.
- 기존 프론트엔드 lint 오류를 정리했습니다.

## Verification

- `npm run lint`
- `npm run build`

## Notes

- 빌드 시 기존 번들 크기 경고가 표시되지만 빌드는 성공합니다.
