### PR TITLE
fix: 숨겨진 모집 질문 답변 정리

### DIFF
--- a/src/pages/site/ApplicationManagePage.tsx
+++ b/src/pages/site/ApplicationManagePage.tsx
@@ -356,8 +356,21 @@ export default function ApplicationManagePage() {
       }
     }
 
+    const submittedAnswers = { ...answers };
+    const submittedFiles = { ...files };
     const payloadAnswers = questionSource.map((q) => {
-      const value = normalizeAnswerValue(answers[q.formQuestionId] ?? null);
+      const visibleForDepartment = shouldShowByDepartment(
+        q.sectionType,
+        q.departmentType,
+        selectedDepartments,
+      );
+      if (!visibleForDepartment) {
+        delete submittedAnswers[q.formQuestionId];
+        delete submittedFiles[q.formQuestionId];
+      }
+      const value = visibleForDepartment
+        ? normalizeAnswerValue(answers[q.formQuestionId] ?? null)
+        : null;
       return { formQuestionId: q.formQuestionId, value: value ?? null };
     });
 
@@ -372,11 +385,13 @@ export default function ApplicationManagePage() {
         answers: payloadAnswers,
       });
 
+      setAnswers(submittedAnswers);
+      setFiles(submittedFiles);
       setSnapshot({
         firstDepartment,
         secondDepartment,
-        answers: { ...answers },
-        files: { ...files },
+        answers: submittedAnswers,
+        files: submittedFiles,
       });
       alert('지원서가 저장되었습니다.');
     } catch {


### PR DESCRIPTION
## 요약
- 지원서 수정 저장 시 현재 선택 부서에 보이지 않는 질문은 null로 전송합니다.
- 저장 성공 후 숨겨진 질문 답변과 파일 상태를 로컬에서도 제거합니다.

## 검증
- npm run build