### PR TITLE
chore: ignore ai workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# AI workspace
+.ai-workspace/


### PR DESCRIPTION
## Summary
- Add `.ai-workspace/` to `.gitignore` so local AI workspace files are not tracked.

## Tests
- Not run: `.gitignore` only change.