### PR TITLE
docs: 커맨드 워크플로우 적용 기준 강화

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,4 +143,31 @@ AI는 아래 작업을 사용자 승인 없이 실행하지 않는다.
 - PR 생성이 포함되는 모든 요청은 `/pr` 명시 여부와 관계없이 `.codex/commands/pr.md`를 따른다.
 - 머지가 포함되는 모든 요청은 `/merge` 명시 여부와 관계없이 `.codex/commands/merge.md`를 따른다.
 
+### Git 작업 요청 해석 규칙
+
+사용자가 명령어를 정확히 쓰지 않아도, 요청 문장에 포함된 최종 목표를 기준으로 필요한 `.codex/commands/*.md`를 모두 읽고 순서대로 따른다.
+
+예:
+
+- "커밋해줘", "변경사항 저장해줘"
+  - `.codex/commands/commit.md`를 읽고 따른다.
+- "푸쉬까지 진행해줘", "push까지 해줘"
+  - `.codex/commands/commit.md`를 읽고 커밋 절차를 따른다.
+  - 커밋 후 push 승인 절차까지 진행한다.
+- "PR 작성까지 진행해줘", "PR 본문 써줘"
+  - `.codex/commands/pr.md`를 읽고 PR 설명 작성 및 `.ai-workspace/pr.md` 저장까지 진행한다.
+  - PR 생성은 별도 승인 없이는 하지 않는다.
+- "PR 생성까지 진행해줘", "PR 올려줘"
+  - `.codex/commands/commit.md`와 `.codex/commands/pr.md`를 모두 읽고 따른다.
+  - 커밋, push, PR 생성은 각 승인 게이트를 지킨다.
+- "PR 푸쉬까지 진행해줘"
+  - PR은 push 이후 생성 가능하므로, 의미가 불명확하면 "push 후 PR 생성"으로 해석한다.
+  - `.codex/commands/commit.md`와 `.codex/commands/pr.md`를 모두 읽고 따른다.
+- "머지까지 진행해줘"
+  - `.codex/commands/commit.md`, `.codex/commands/pr.md`, `.codex/commands/merge.md`를 모두 읽고 순서대로 따른다.
+  - 커밋, push, PR 생성, merge는 각 승인 게이트를 지킨다.
+
+요청이 "까지 진행" 형태여도 승인 게이트는 생략하지 않는다.
+단, 사용자가 직전 단계의 실행 명령과 대상을 이미 확인한 뒤 "승인", "진행", "계속"이라고 답하면 해당 게이트의 승인으로 본다.
+
 `.codex/commands`의 내용이 이 파일과 충돌하면 `AGENTS.md`를 우선한다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,7 @@ AI는 아래 작업을 사용자 승인 없이 실행하지 않는다.
 
 ## Codex 커맨드 워크플로우
 
-사용자가 아래 명령을 요청하면 `.codex/commands/<command>.md`를 먼저 읽고 해당 절차를 따른다.
+사용자가 아래 명령을 요청하거나 요청 내용에 해당 작업이 포함되면 `.codex/commands/<command>.md`를 먼저 읽고 해당 절차를 따른다.
 
 | 명령 | 용도 |
 |---|---|
@@ -138,5 +138,9 @@ AI는 아래 작업을 사용자 승인 없이 실행하지 않는다.
 | `/merge` | 승인 후 PR 병합 |
 
 `/feature`는 작은 문구 수정, 단순 스타일 조정, 파일 하나짜리 버그 수정에는 과할 수 있다. 그런 경우 `/plan`, `/impl`, `/review`, `/commit`을 필요한 만큼만 사용한다.
+
+- 커밋이 포함되는 모든 요청은 `/commit` 명시 여부와 관계없이 `.codex/commands/commit.md`를 따른다.
+- PR 생성이 포함되는 모든 요청은 `/pr` 명시 여부와 관계없이 `.codex/commands/pr.md`를 따른다.
+- 머지가 포함되는 모든 요청은 `/merge` 명시 여부와 관계없이 `.codex/commands/merge.md`를 따른다.
 
 `.codex/commands`의 내용이 이 파일과 충돌하면 `AGENTS.md`를 우선한다.


### PR DESCRIPTION
# 요약

AGENTS.md의 Codex 커맨드 워크플로우 적용 기준을 명령어 문자열 기준에서 작업 포함 기준으로 강화합니다.

# 작업 내용

- [x] `/commit` 명시 여부와 관계없이 커밋 포함 요청은 `commit.md`를 따르도록 명시
- [x] `/pr` 명시 여부와 관계없이 PR 생성 포함 요청은 `pr.md`를 따르도록 명시
- [x] `/merge` 명시 여부와 관계없이 머지 포함 요청은 `merge.md`를 따르도록 명시
- [x] 커맨드 워크플로우 안내 문장을 작업 포함 기준으로 보완

# 테스트 방법

- 문서 수정만 포함하므로 `npm run lint`, `npm run build`는 실행하지 않았습니다.
- `git diff main...HEAD --stat`로 변경 범위를 확인했습니다.

# 기타

- 코드, API, 라우팅, 환경 변수, 배포 설정 영향은 없습니다.
- 민감정보 변경은 없습니다.