### PR TITLE
fix: 관리자 지원서 파일 답변 판별 수정

### DIFF
--- a/src/pages/admin/AdminApplicationDetailPage.tsx
+++ b/src/pages/admin/AdminApplicationDetailPage.tsx
@@ -31,8 +31,9 @@ function isLikelyFileKey(value: string) {
   const trimmed = value.trim();
   if (!trimmed) return false;
   if (isLikelyUrl(trimmed)) return false;
+  if (/\s/.test(trimmed)) return false;
   return (
-    trimmed.includes('/') ||
+    /^uploads\/recruit\/answers\/.+/i.test(trimmed) ||
     /\.(pdf|docx?|pptx?|xlsx?|zip|hwp|png|jpe?g|webp)$/i.test(trimmed)
   );
 }


### PR DESCRIPTION
# 요약

관리자 지원서 상세 화면에서 일반 텍스트 답변이 파일 답변으로 오인되어 파일 키 복사 UI가 표시되던 문제를 수정합니다.

# 작업 내용

- [x] 파일 key 추정 조건에서 단순 `/` 포함 여부를 제거
- [x] 공백이 포함된 긴 텍스트는 파일 key 후보에서 제외
- [x] 실제 지원서 업로드 key prefix(`uploads/recruit/answers/...`) 또는 파일 확장자 형태만 파일 key fallback으로 판별

# 테스트 방법

- `npm run lint`
- `npm run build`

# 기타

- API, 라우팅, 환경 변수 변경은 없습니다.
- 보안/민감정보 변경은 없습니다.
- `npm run build`에서 Vite chunk size 경고가 표시되었지만 빌드는 성공했습니다.