### PR TITLE
docs: 리팩토링 계획 완료 아카이브 및 테스트 컨벤션 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,18 @@ AI는 아래 작업을 사용자 승인 없이 실행하지 않는다.
 
 ---
 
+## 테스트 컨벤션
+
+**작성 의무**: 새 로직(유틸, api 모듈, 훅) 추가 또는 기존 로직 변경 시 해당 부분의 테스트를 함께 작성한다.
+
+- 도구: Vitest + React Testing Library (`npm test` / `npm run test:watch`)
+- 위치: 대상 파일 옆에 `*.test.ts(x)` (예: `src/utils/date.test.ts`)
+- 우선순위: 순수 함수·api 모듈 > 훅 > 컴포넌트. 스타일·마크업만 바뀌는 컴포넌트 테스트는 강제하지 않는다
+- 깡통 테스트 금지 — assertion 없는 테스트, 구현 복사 테스트는 작성하지 않는다
+- 참고 예시: `src/api/client.test.ts` (fetch mock, 토큰 부착·에러 처리), `src/utils/date.test.ts` (경계값)
+
+---
+
 ## 핸드오프/상태 문서 컨벤션
 
 에이전트가 작업 인계 문서(핸드오프, 계획, 상태 파일)를 작성할 때:

--- a/docs/fe-cicd-refactoring-plan.md
+++ b/docs/fe-cicd-refactoring-plan.md
@@ -1,5 +1,9 @@
 # FE CI/CD·하네스 리팩토링 계획
 
+> ✅ **완료 (2026-07-13)** — ⓪~⑤ 전부 main 병합·운영 반영됨. 기록용 아카이브.
+> 최종 상태: GHCR 이미지 배포(nginx/1.27.5 서빙 확인), PR 게이트 5종 + main ruleset 활성,
+> Vitest 14개, GA4 빌드 변수 이관, healthcheck IPv4 수정. 기존 Coolify Static 리소스는 중지(일주일 후 삭제).
+
 > 작성: 2026-07-12 · 기준: origin/main `3f89ced` · 배포 방향: Coolify 단일화 (결정됨)
 > 근거: 백엔드(cow-mju-craft)에서 검증 완료된 패턴 이식. 완료 시 상단에 ✅ 배너 후 아카이브.
 


### PR DESCRIPTION
계획 문서에 ✅ 완료 배너(핸드오프 컨벤션 준수), AGENTS.md에 Vitest 테스트 컨벤션 섹션 추가. 문서만 변경.