### PR TITLE
chore: dependabot 메이저 버전 자동 PR 제외

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,25 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    # 메이저 버전 업데이트는 호환성이 깨질 수 있어 자동 PR 대상에서 제외한다.
+    # 필요하면 직접 버전을 확인하고 개별적으로 업데이트한다.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
+    # Dockerfile base image(node, nginx)도 메이저 버전은 자동 반영 대상에서 제외.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## 요약
dependabot이 vite, @vitejs/plugin-react, node(도커 base image) 등을 메이저 버전까지 자동으로 PR 올려서 CI가 깨지거나 운영 base image가 통째로 바뀔 뻔함.

## 작업 내용
npm/github-actions/docker 3개 생태계 전부에 semver-major ignore 규칙 추가. 메이저 버전은 앞으로 자동 PR 대상에서 제외, 필요 시 개별 확인 후 수동 업데이트.

## 참고
기존에 열려 있던 메이저 bump PR(vite-8.1.4, plugin-react-6.0.3, typescript-7.0.2, node-26-alpine)은 닫아야 함.