### PR TITLE
feat: 배포 identity 확인 및 롤백 워크플로 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           context: .
           push: true
+          build-args: |
+            BUILD_SHA=${{ github.event.workflow_run.head_sha }}
           tags: |
             ${{ env.IMAGE }}:latest
             ${{ env.IMAGE }}:${{ github.event.workflow_run.head_sha }}
@@ -53,22 +55,31 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.COOLIFY_API_TOKEN }}"
 
       - name: Verify deployment (smoke check)
+        env:
+          EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           BASE_URL="${{ vars.FE_BASE_URL || 'https://mju-craft.shop' }}"
           echo "smoke target: ${BASE_URL}"
-          # 200 + 실제 SPA HTML인지 확인 (200만 보면 안 됨 — 백엔드 교훈)
+          echo "expected sha: ${EXPECTED_SHA}"
+          # SPA HTML이 뜨는지 + /version.json이 이번에 배포한 커밋과 일치하는지 함께 확인한다.
+          # (200만 보면 안 됨 — 캐시되거나 이전 버전이 그대로 떠 있어도 200이 나올 수 있음)
           ok=""
           for i in $(seq 1 20); do
             sleep 15
             body=$(curl -s --max-time 10 "${BASE_URL}/" || echo "")
-            if echo "$body" | grep -q 'id="root"'; then
-              echo "attempt ${i}/20: SPA HTML OK"
+            if ! echo "$body" | grep -q 'id="root"'; then
+              echo "attempt ${i}/20: SPA HTML 아직 아님"
+              continue
+            fi
+            deployed_sha=$(curl -s --max-time 10 "${BASE_URL}/version.json" | grep -o '"sha":"[^"]*"' | cut -d'"' -f4 || echo "")
+            if [ "$deployed_sha" = "$EXPECTED_SHA" ]; then
+              echo "attempt ${i}/20: OK (배포된 sha=${deployed_sha})"
               ok=1
               break
             fi
-            echo "attempt ${i}/20: 아직 정상 응답 아님"
+            echo "attempt ${i}/20: SPA는 응답하나 sha 불일치 (배포됨=${deployed_sha:-없음}, 기대값=${EXPECTED_SHA})"
           done
           if [ -z "$ok" ]; then
-            echo "::error::배포 후 smoke check 실패 — 5분 내 정상 HTML 미확인"
+            echo "::error::배포 후 smoke check 실패 — 5분 내 기대한 커밋(${EXPECTED_SHA})으로 확인 안 됨"
             exit 1
           fi

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -1,0 +1,82 @@
+name: Rollback FE Deployment
+
+# 배포된 커밋에 문제가 있을 때, 이미 GHCR에 올라간 특정 커밋 SHA 이미지를
+# 다시 :latest로 재태깅해서 Coolify가 그 버전을 pull하도록 되돌린다.
+# 새로 빌드하지 않고 기존 이미지를 재사용하므로, 대상 SHA는 과거에
+# main으로 머지되어 deploy.yml이 실제로 push한 커밋이어야 한다.
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "롤백할 커밋 SHA (전체 40자리, ghcr.io에 :SHA 태그로 이미 존재해야 함)"
+        required: true
+        type: string
+
+concurrency:
+  group: deploy-fe-main
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+
+    env:
+      IMAGE: ghcr.io/cow-mju-craft/cowmjucraft-fe
+
+    steps:
+      - name: 입력값 검증
+        run: |
+          sha="${{ inputs.sha }}"
+          if ! echo "$sha" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "::error::sha는 40자리 소문자 16진수 커밋 해시여야 합니다. 입력값: ${sha}"
+            exit 1
+          fi
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 대상 SHA 이미지를 :latest로 재태깅 후 push
+        run: |
+          docker pull "${{ env.IMAGE }}:${{ inputs.sha }}"
+          docker tag "${{ env.IMAGE }}:${{ inputs.sha }}" "${{ env.IMAGE }}:latest"
+          docker push "${{ env.IMAGE }}:latest"
+
+      - name: Trigger Coolify deploy
+        run: |
+          curl -fSs -X GET "${{ secrets.COOLIFY_FE_WEBHOOK_URL }}" \
+            -H "Authorization: Bearer ${{ secrets.COOLIFY_API_TOKEN }}"
+
+      - name: Verify rollback (smoke check)
+        env:
+          EXPECTED_SHA: ${{ inputs.sha }}
+        run: |
+          BASE_URL="${{ vars.FE_BASE_URL || 'https://mju-craft.shop' }}"
+          echo "smoke target: ${BASE_URL}"
+          echo "expected sha (rollback target): ${EXPECTED_SHA}"
+          ok=""
+          for i in $(seq 1 20); do
+            sleep 15
+            body=$(curl -s --max-time 10 "${BASE_URL}/" || echo "")
+            if ! echo "$body" | grep -q 'id="root"'; then
+              echo "attempt ${i}/20: SPA HTML 아직 아님"
+              continue
+            fi
+            deployed_sha=$(curl -s --max-time 10 "${BASE_URL}/version.json" | grep -o '"sha":"[^"]*"' | cut -d'"' -f4 || echo "")
+            if [ "$deployed_sha" = "$EXPECTED_SHA" ]; then
+              echo "attempt ${i}/20: OK (롤백 확인, sha=${deployed_sha})"
+              ok=1
+              break
+            fi
+            echo "attempt ${i}/20: SPA는 응답하나 sha 불일치 (배포됨=${deployed_sha:-없음}, 기대값=${EXPECTED_SHA})"
+          done
+          if [ -z "$ok" ]; then
+            echo "::error::롤백 후 smoke check 실패 — 5분 내 기대한 커밋(${EXPECTED_SHA})으로 확인 안 됨"
+            exit 1
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,11 @@ ENV VITE_GA4_REPORT_URL=$VITE_GA4_REPORT_URL
 
 RUN npm run build
 
+# 배포된 이미지가 실제로 어떤 커밋인지 런타임에 확인할 수 있도록 버전 파일을 심는다.
+# (로컬 빌드 등 값이 없을 때는 "unknown"으로 남겨 스모크 체크가 실패로 감지하게 한다.)
+ARG BUILD_SHA=unknown
+RUN echo "{\"sha\":\"${BUILD_SHA}\"}" > /app/dist/version.json
+
 # ---------- serve stage ----------
 FROM nginx:1.31-alpine
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -15,6 +15,12 @@ server {
         return 404;
     }
 
+    # 배포 스모크 체크가 실제 배포된 커밋 SHA를 확인하는 용도라 캐시되면 안 된다.
+    location = /version.json {
+        add_header Cache-Control "no-store";
+        try_files $uri =404;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
## 배경
배포 후 실제로 어떤 커밋이 떠 있는지 확인할 방법이 없었고, 문제 발생 시 특정 버전으로
되돌리는 절차도 없었음.

## 변경
- Dockerfile: 빌드 시 `BUILD_SHA`를 `/version.json`으로 심음
- nginx.conf: `/version.json`은 `no-store`로 캐시 방지
- deploy.yml: 스모크 체크를 "SPA HTML 응답 여부"에서 "배포된 sha가 방금 빌드한
  커밋과 실제로 일치하는지"로 강화
- rollback.yml (신규): `workflow_dispatch`로 과거 커밋 SHA 입력 시 GHCR에 이미
  있는 해당 SHA 이미지를 `:latest`로 재태깅/push하고 Coolify 재배포 트리거

## 확인한 점
Coolify 앱은 `ghcr.io/cow-mju-craft/cowmjucraft-fe:latest`만 pull하도록 고정되어
있어서, Coolify 설정을 바꾸지 않고 GHCR 재태깅만으로 롤백이 가능함.

## 검증
- lint / tsc 통과 확인
- YAML 문법 검증 (`yaml.safe_load`)
- Docker 없는 환경이라 실제 `docker build`는 CI에서 최종 검증 필요