### PR TITLE
feat: 인증 상태 중앙화

### DIFF
--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-// 401 시 clearAuth 호출 검증을 위해 mock
+// 401 시 clearAuth 호출 검증 + 토큰 조회를 auth 모듈에 위임하는지 확인하기 위해 mock
 vi.mock('../utils/auth', () => ({
   clearAuth: vi.fn(),
+  getAccessToken: vi.fn(() => null),
 }));
 
 import { api, ApiError, withApiBase } from './client';
-import { clearAuth } from '../utils/auth';
+import { clearAuth, getAccessToken } from '../utils/auth';
 
 function mockFetch(status: number, body: unknown) {
   return vi.fn().mockResolvedValue(
@@ -18,8 +19,8 @@ function mockFetch(status: number, body: unknown) {
 }
 
 beforeEach(() => {
-  localStorage.clear();
   vi.clearAllMocks();
+  vi.mocked(getAccessToken).mockReturnValue(null);
 });
 
 afterEach(() => {
@@ -46,7 +47,7 @@ describe('api', () => {
   });
 
   it('토큰이 있으면 Authorization 헤더를 붙인다', async () => {
-    localStorage.setItem('accessToken', 'tok123');
+    vi.mocked(getAccessToken).mockReturnValue('tok123');
     const f = mockFetch(200, { resultType: 'SUCCESS', httpStatusCode: 200, message: '', data: null });
     vi.stubGlobal('fetch', f);
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,4 @@
-﻿import { clearAuth } from "../utils/auth";
+﻿import { clearAuth, getAccessToken } from "../utils/auth";
 
 type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 
@@ -18,12 +18,6 @@ export class ApiError extends Error {
     this.status = status;
     this.body = body;
   }
-}
-
-const TOKEN_KEY = import.meta.env.VITE_TOKEN_KEY ?? "accessToken";
-
-function getAccessToken(): string | null {
-  return localStorage.getItem(TOKEN_KEY);
 }
 
 type RequestOptions = {

--- a/src/components/AdminHeaderDesktop.tsx
+++ b/src/components/AdminHeaderDesktop.tsx
@@ -1,8 +1,7 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { adminApi } from '../api/admin';
-
-const TOKEN_KEY = import.meta.env.VITE_TOKEN_KEY ?? 'access_token';
+import { clearAuth } from '../utils/auth';
 
 const LEADING_NAV_ITEMS = [
   { key: 'edit', label: '회원정보', href: '/admin#edit' },
@@ -143,7 +142,7 @@ export default function AdminHeaderDesktop() {
             try {
               await adminApi.logout();
             } finally {
-              localStorage.removeItem(TOKEN_KEY);
+              clearAuth();
               navigate('/');
             }
           }}

--- a/src/components/AdminHeaderMobile.tsx
+++ b/src/components/AdminHeaderMobile.tsx
@@ -2,8 +2,8 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useEffect, useRef, useState, type TouchEvent } from 'react';
 import { createPortal } from 'react-dom';
 import { adminApi } from '../api/admin';
+import { clearAuth } from '../utils/auth';
 
-const TOKEN_KEY = import.meta.env.VITE_TOKEN_KEY ?? 'access_token';
 const SWIPE_CLOSE_THRESHOLD = 60;
 
 const LEADING_NAV_ITEMS = [
@@ -187,7 +187,7 @@ export default function AdminHeaderMobile({
             try {
               await adminApi.logout();
             } finally {
-              localStorage.removeItem(TOKEN_KEY);
+              clearAuth();
               navigate('/');
             }
           }}

--- a/src/features/mypage/useMyPage.ts
+++ b/src/features/mypage/useMyPage.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { mypageApi } from '../../api/mypage';
 import type { MyPageProfile } from '../../api/mypage';
 import { ApiError } from '../../api/client';
-import { setAuth } from '../../utils/auth';
+import { getAccessToken, setAuth } from '../../utils/auth';
 import type { ProfileForm } from './Types';
 import { DEFAULT_FORM } from './Types';
 
@@ -159,7 +159,7 @@ export default function useMyPage() {
       }
 
       setAuth({
-        accessToken: localStorage.getItem('accessToken') ?? '',
+        accessToken: getAccessToken() ?? '',
         userName: state.form.name,
       });
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import './index.css';
 import App from './App';
 import ToastProvider from './components/toast/ToastProvider';
 import ConfirmProvider from './components/confirm/ConfirmProvider';
+import { AUTH_CHANGED_EVENT } from './utils/auth';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -14,6 +15,13 @@ const queryClient = new QueryClient({
       retry: 1,
     },
   },
+});
+
+// 로그인/로그아웃/401(세션 만료)로 인증 상태가 바뀌면 캐시된 서버 데이터를 비운다.
+// 그대로 두면 로그아웃 후 다른 관리자가 로그인했을 때 이전 세션의 데이터가
+// 화면에 잠깐 보일 수 있다.
+window.addEventListener(AUTH_CHANGED_EVENT, () => {
+  queryClient.clear();
 });
 
 const showQueryDevtools =

--- a/src/pages/site/LoginPage.tsx
+++ b/src/pages/site/LoginPage.tsx
@@ -12,8 +12,6 @@ type AdminLoginResponse = {
   loginId?: string;
 };
 
-const LOGIN_ID_KEY = 'admin_login_id';
-
 export default function LoginPage() {
   const navigate = useNavigate();
   const confirm = useConfirm();
@@ -93,8 +91,6 @@ export default function LoginPage() {
 
       const name = (result.loginId ?? userId.trim()).trim() || 'USER';
       setAuth({ accessToken: result.accessToken, userName: name });
-
-      if (result.loginId) localStorage.setItem(LOGIN_ID_KEY, result.loginId);
 
       setStatus('success');
       navigate('/admin', { replace: true });

--- a/src/utils/auth.test.ts
+++ b/src/utils/auth.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  AUTH_CHANGED_EVENT,
+  clearAuth,
+  getAccessToken,
+  getUserName,
+  isLoggedIn,
+  setAuth,
+} from './auth';
+
+beforeEach(() => {
+  sessionStorage.clear();
+  localStorage.clear();
+});
+
+describe('auth', () => {
+  it('setAuth는 sessionStorage에 저장하고 localStorage에는 남기지 않는다', () => {
+    setAuth({ accessToken: 'tok123', userName: '홍길동' });
+
+    expect(sessionStorage.getItem('accessToken')).toBe('tok123');
+    expect(sessionStorage.getItem('userName')).toBe('홍길동');
+    expect(localStorage.length).toBe(0);
+  });
+
+  it('getAccessToken / getUserName / isLoggedIn이 setAuth 이후 값을 반영한다', () => {
+    expect(isLoggedIn()).toBe(false);
+
+    setAuth({ accessToken: 'tok123', userName: '홍길동' });
+
+    expect(getAccessToken()).toBe('tok123');
+    expect(getUserName()).toBe('홍길동');
+    expect(isLoggedIn()).toBe(true);
+  });
+
+  it('clearAuth는 토큰과 사용자명을 모두 지운다', () => {
+    setAuth({ accessToken: 'tok123', userName: '홍길동' });
+    clearAuth();
+
+    expect(getAccessToken()).toBeNull();
+    expect(getUserName()).toBeNull();
+    expect(isLoggedIn()).toBe(false);
+  });
+
+  it('setAuth / clearAuth는 AUTH_CHANGED_EVENT를 발생시킨다', () => {
+    const listener = vi.fn();
+    window.addEventListener(AUTH_CHANGED_EVENT, listener);
+
+    setAuth({ accessToken: 'tok123' });
+    clearAuth();
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    window.removeEventListener(AUTH_CHANGED_EVENT, listener);
+  });
+
+  it('userName 없이 setAuth를 호출하면 기존 userName을 지운다', () => {
+    setAuth({ accessToken: 'tok123', userName: '홍길동' });
+    setAuth({ accessToken: 'tok456' });
+
+    expect(getAccessToken()).toBe('tok456');
+    expect(getUserName()).toBeNull();
+  });
+});

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,11 +1,16 @@
 const TOKEN_KEY = import.meta.env.VITE_TOKEN_KEY ?? 'accessToken';
 const USER_NAME_KEY = 'userName';
 
+// 토큰 get/set/clear는 반드시 이 모듈을 통해서만 접근한다.
+// - 탭을 닫으면 사라지도록 localStorage 대신 sessionStorage를 쓴다
+//   (관리자 토큰이 브라우저를 껐다 켜도 남아있지 않게 하기 위함).
+// - 다른 파일에서 직접 localStorage/sessionStorage로 토큰을 읽거나 쓰면
+//   키 이름이 어긋나거나(과거 실제 버그였음) 로그아웃이 반쪽으로 처리될 수 있다.
 export const AUTH_CHANGED_EVENT = 'auth-changed';
 
 export function getAccessToken(): string | null {
   try {
-    return localStorage.getItem(TOKEN_KEY);
+    return sessionStorage.getItem(TOKEN_KEY);
   } catch {
     return null;
   }
@@ -13,7 +18,7 @@ export function getAccessToken(): string | null {
 
 export function getUserName(): string | null {
   try {
-    const v = localStorage.getItem(USER_NAME_KEY);
+    const v = sessionStorage.getItem(USER_NAME_KEY);
     return v && v.trim().length > 0 ? v.trim() : null;
   } catch {
     return null;
@@ -30,11 +35,11 @@ export function setAuth(payload: {
   userName?: string | null;
 }) {
   try {
-    localStorage.setItem(TOKEN_KEY, payload.accessToken);
+    sessionStorage.setItem(TOKEN_KEY, payload.accessToken);
     if (payload.userName && payload.userName.trim()) {
-      localStorage.setItem(USER_NAME_KEY, payload.userName.trim());
+      sessionStorage.setItem(USER_NAME_KEY, payload.userName.trim());
     } else {
-      localStorage.removeItem(USER_NAME_KEY);
+      sessionStorage.removeItem(USER_NAME_KEY);
     }
   } finally {
     window.dispatchEvent(new Event(AUTH_CHANGED_EVENT));
@@ -43,8 +48,8 @@ export function setAuth(payload: {
 
 export function clearAuth() {
   try {
-    localStorage.removeItem(TOKEN_KEY);
-    localStorage.removeItem(USER_NAME_KEY);
+    sessionStorage.removeItem(TOKEN_KEY);
+    sessionStorage.removeItem(USER_NAME_KEY);
   } finally {
     window.dispatchEvent(new Event(AUTH_CHANGED_EVENT));
   }


### PR DESCRIPTION
## 배경
토큰 get/set/clear가 auth.ts를 거치지 않고 여러 곳에서 직접
localStorage를 건드리고 있었음. 그 중 실제 버그로 이어질 수 있는 지점들:

- `client.ts`가 자체 TOKEN_KEY 상수로 localStorage를 직접 읽음 (auth.ts와 로직 중복)
- `useMyPage.ts`가 `'accessToken'`을 하드코딩해서 읽음 — `VITE_TOKEN_KEY`가
  auth.ts 기본값과 다르게 설정되면 빈 문자열로 토큰을 덮어씀
- `AdminHeaderDesktop/Mobile`의 로그아웃 버튼이 fallback 키로
  `'access_token'`(스네이크 케이스)을 써서 auth.ts의 `'accessToken'`과
  어긋남 — env 변수 미설정 시 로그아웃해도 실제 토큰이 안 지워짐

## 변경
- `auth.ts`: 저장소를 localStorage → sessionStorage로 전환
- `client.ts`/`useMyPage.ts`/`AdminHeaderDesktop.tsx`/`AdminHeaderMobile.tsx`:
  전부 auth.ts의 `getAccessToken()`/`clearAuth()`로 통일
- `main.tsx`: 인증 상태 변경(로그인/로그아웃/401) 시 React Query 캐시 clear
- `LoginPage.tsx`: 죽은 localStorage 기록 제거
- `auth.ts` 단위 테스트 추가

Cookie + HttpOnly 전환은 백엔드 협의 필요해 범위 밖으로 남김.

## 검증
lint / tsc / vitest(26) / vite build 통과