### PR TITLE
chore: dependabot에서 짝 패키지 그룹핑 (react/react-dom 등)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,33 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+    # 서로 버전이 어긋나면 안 되는(또는 항상 같이 다니는) 패키지들은 묶어서
+    # 하나의 PR로만 올라오게 한다. react와 react-dom이 따로 올라가서
+    # 버전이 어긋나 프로덕션이 죽었던 사고(2026-07) 재발 방지.
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+      tanstack-query:
+        patterns:
+          - "@tanstack/react-query*"
+      dnd-kit:
+        patterns:
+          - "@dnd-kit/*"
+      eslint-tooling:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "typescript-eslint"
+          - "globals"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## 요약
dependabot.yml에 groups 설정 추가 — react/react-dom 등 서로 버전이 어긋나면 안 되는 패키지들을 하나의 PR로 묶음.

## 작업 내용
- [x] react 그룹: react, react-dom, @types/react, @types/react-dom
- [x] tailwind, tanstack-query, dnd-kit, eslint-tooling 그룹도 함께 정리

## 배경
react만 19.2.7로 올라가고 react-dom은 19.2.0에 남아 버전이 어긋나면서 프로덕션이 전부 죽었던 사고(오늘) 재발 방지용.

## 테스트 방법
- [x] YAML 문법 검증 (yaml.safe_load)
- [ ] 코드 변경 없음 — npm run build/test 불필요