### PR TITLE
feat: 런타임 보안 헤더 추가 및 다음 우편번호 스크립트 지연 로드

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN echo "{\"sha\":\"${BUILD_SHA}\"}" > /app/dist/version.json
 FROM nginx:1.31-alpine
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY security-headers.conf /etc/nginx/security-headers.conf
 COPY --from=builder /app/dist /usr/share/nginx/html
 
 EXPOSE 80

--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
     <link rel="icon" type="image/png" href="/mjucraftLogo_Blue_Round.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>명지공방</title>
-    <script src="https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,8 +4,15 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # nginx add_header는 location이 자기 add_header를 따로 선언하면 부모(server)
+    # 쪽 add_header를 상속하지 않고 통째로 무시한다. /assets/, /version.json은
+    # 각자 Cache-Control을 따로 선언하므로 그 location들에도 이 include를
+    # 반복해서 보안 헤더가 누락되지 않게 한다.
+    include /etc/nginx/security-headers.conf;
+
     # 해시 붙은 정적 자산은 장기 캐시
     location /assets/ {
+        include /etc/nginx/security-headers.conf;
         add_header Cache-Control "public, max-age=31536000, immutable";
         try_files $uri =404;
     }
@@ -17,6 +24,7 @@ server {
 
     # 배포 스모크 체크가 실제 배포된 커밋 SHA를 확인하는 용도라 캐시되면 안 된다.
     location = /version.json {
+        include /etc/nginx/security-headers.conf;
         add_header Cache-Control "no-store";
         try_files $uri =404;
     }

--- a/security-headers.conf
+++ b/security-headers.conf
@@ -1,0 +1,19 @@
+# 공용 보안 헤더 조각.
+#
+# nginx의 add_header는 부모 컨텍스트(server)에서 선언해도, 자식 location이
+# 자기 add_header를 하나라도 선언하면 부모 쪽 add_header를 전부 무시하고
+# 자기 것만 적용한다(상속되지 않음). 그래서 add_header를 따로 쓰는
+# /assets/, /version.json location에서도 이 파일을 include해서 보안
+# 헤더가 누락되지 않게 한다.
+#
+# CSP는 아직 Report-Only 단계: 위반 사항을 콘솔에서 관찰한 뒤 문제
+# 없음을 확인하고 나서 별도 PR에서 강제(enforce) 모드로 전환한다.
+# img-src에 https:를 넓게 허용한 이유: 업로드 이미지가 백엔드가 발급하는
+# S3 URL(도메인이 코드에 고정돼 있지 않음)이라 정확한 도메인을 알 수
+# 없어서다. blob:/data:는 관리자 화면의 이미지 업로드 미리보기(ObjectURL)에
+# 필요하다.
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-Frame-Options "DENY" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' https://t1.daumcdn.net https://www.googletagmanager.com; connect-src 'self' https://api.mju-craft.shop https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com; img-src 'self' data: blob: https:; style-src 'self'; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'" always;

--- a/src/features/mypage/MyPageAddressSection.tsx
+++ b/src/features/mypage/MyPageAddressSection.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import type { AddressForm, ProfileForm } from './Types';
+import { loadDaumPostcodeScript } from '../../utils/daumPostcode';
 
 const REQUIRED = 'text-rose-500 ml-1';
 
@@ -27,26 +28,6 @@ const formatPhoneWithCursor = (value: string, cursor: number) => {
 
   return { formatted, nextCursor };
 };
-
-type DaumPostcodeResult = {
-  zonecode: string;
-  roadAddress?: string;
-  jibunAddress?: string;
-};
-
-type DaumPostcode = {
-  new (options: { oncomplete: (data: DaumPostcodeResult) => void }): {
-    open: (options?: { left?: number; top?: number }) => void;
-  };
-};
-
-declare global {
-  interface Window {
-    daum?: {
-      Postcode: DaumPostcode;
-    };
-  }
-}
 
 type Props = {
   form: ProfileForm;
@@ -79,7 +60,12 @@ export default function MyPageAddressSection({
     []
   );
 
-  const openPostcode = () => {
+  const openPostcode = async () => {
+    try {
+      await loadDaumPostcodeScript();
+    } catch {
+      return;
+    }
     if (!window.daum) return;
 
     const width = 500;

--- a/src/pages/site/OrderPage.tsx
+++ b/src/pages/site/OrderPage.tsx
@@ -17,31 +17,12 @@ import {
   loadOrderDraft,
   saveOrderDraft,
 } from '../../utils/orderDraft';
+import { loadDaumPostcodeScript } from '../../utils/daumPostcode';
 
 type OrderLocationState = {
   source?: 'cart' | 'direct';
   items?: CartItem[];
 };
-
-type DaumPostcodeResult = {
-  zonecode: string;
-  roadAddress?: string;
-  jibunAddress?: string;
-};
-
-type DaumPostcode = {
-  new (options: { oncomplete: (data: DaumPostcodeResult) => void }): {
-    open: (options?: { left?: number; top?: number }) => void;
-  };
-};
-
-declare global {
-  interface Window {
-    daum?: {
-      Postcode: DaumPostcode;
-    };
-  }
-}
 
 type BuyerType = 'STUDENT' | 'STAFF' | 'EXTERNAL';
 type CampusType = 'SEOUL' | 'YONGIN';
@@ -537,7 +518,16 @@ export default function OrderPage() {
     }
   };
 
-  const openDeliveryPostcode = () => {
+  const openDeliveryPostcode = async () => {
+    try {
+      await loadDaumPostcodeScript();
+    } catch {
+      toast.error(
+        '주소 검색 스크립트를 불러오지 못했어요. 잠시 후 다시 시도해주세요.',
+      );
+      return;
+    }
+
     if (!window.daum) {
       toast.error(
         '주소 검색 스크립트를 불러오지 못했어요. 잠시 후 다시 시도해주세요.',

--- a/src/utils/daumPostcode.ts
+++ b/src/utils/daumPostcode.ts
@@ -1,0 +1,66 @@
+// 다음(Daum) 우편번호 서비스 스크립트를 지연 로드한다.
+// 이전에는 index.html에서 모든 페이지에 무조건 스크립트를 심어놨는데,
+// 실제로 주소 검색을 쓰는 화면은 일부(주문/마이페이지)뿐이라
+// 사용 시점에만 불러오도록 바꿔 불필요한 서드파티 스크립트 로드를 줄인다.
+export type DaumPostcodeResult = {
+  zonecode: string;
+  roadAddress?: string;
+  jibunAddress?: string;
+};
+
+type DaumPostcodeConstructor = {
+  new (options: {
+    oncomplete: (data: DaumPostcodeResult) => void;
+  }): {
+    open: (options?: { left?: number; top?: number }) => void;
+  };
+};
+
+declare global {
+  interface Window {
+    daum?: {
+      Postcode: DaumPostcodeConstructor;
+    };
+  }
+}
+
+const SCRIPT_ID = 'daum-postcode-script';
+const SCRIPT_SRC =
+  'https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js';
+
+let loadPromise: Promise<void> | null = null;
+
+export function loadDaumPostcodeScript(): Promise<void> {
+  if (typeof window === 'undefined') return Promise.resolve();
+  if (window.daum?.Postcode) return Promise.resolve();
+
+  if (loadPromise) return loadPromise;
+
+  loadPromise = new Promise((resolve, reject) => {
+    const existing = document.getElementById(
+      SCRIPT_ID,
+    ) as HTMLScriptElement | null;
+
+    if (existing) {
+      existing.addEventListener('load', () => resolve());
+      existing.addEventListener('error', () => {
+        loadPromise = null;
+        reject(new Error('다음 우편번호 스크립트를 불러오지 못했어요.'));
+      });
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.id = SCRIPT_ID;
+    script.src = SCRIPT_SRC;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => {
+      loadPromise = null;
+      reject(new Error('다음 우편번호 스크립트를 불러오지 못했어요.'));
+    };
+    document.head.appendChild(script);
+  });
+
+  return loadPromise;
+}


### PR DESCRIPTION
# 요약

nginx에 보안 헤더(X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, CSP)를 추가하고, 다음 우편번호 스크립트를 지연 로드로 전환한다.

# 작업 내용

- [ ] nginx 보안 헤더 추가 (security-headers.conf)
- [ ] 다음 우편번호 스크립트 지연 로드 전환

# 기술적 변경 포인트

- add_header는 location이 자기 add_header를 선언하면 부모(server) 헤더를 상속하지 않아, security-headers.conf로 분리 후 /assets/, /version.json location에서도 반복 include
- Dockerfile에 security-headers.conf COPY 추가
- CSP는 1단계로 Report-Only만 적용 (강제 전환은 위반 관찰 후 별도 PR)

# 테스트 방법

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`

# 배포 영향

- Docker 이미지에 security-headers.conf 파일 추가됨. 환경 변수 변경 없음.

# 보안 / 민감정보 영향

- CSP는 Report-Only라 아직 실제 차단은 없음. 콘솔에 위반 로그만 쌓임 — 배포 후 모니터링 필요.
- img-src에 https: 허용(백엔드 S3 URL 도메인이 코드에 고정되지 않아서), blob:/data:는 관리자 이미지 업로드 미리보기용.

# 기타 (논의하고 싶은 부분)

배포 후 일정 기간 콘솔에서 CSP 위반 로그 관찰 필요. 문제 없으면 후속 PR에서 Report-Only → 강제 모드로 전환.

close #이슈번호