### PR TITLE
feat: CodeQL 및 Docker 이미지 취약점 스캔(Trivy)/SBOM 추가

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: CodeQL
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    # 매주 월요일 04:00 UTC(한국시간 13:00) — push/PR 없이도 새로 발견된
+    # 취약 패턴(CodeQL 쿼리 업데이트)을 정기적으로 잡아내기 위함
+    - cron: "0 4 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: CodeQL 초기화
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+
+      - name: CodeQL 분석 (Security 탭에 결과 업로드)
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -1,0 +1,88 @@
+name: Image Security Scan
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "Dockerfile"
+      - "nginx.conf"
+      - "security-headers.conf"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/image-scan.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - "Dockerfile"
+      - "nginx.conf"
+      - "security-headers.conf"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/image-scan.yml"
+  schedule:
+    # 매주 월요일 04:00 UTC — 코드 변경 없이도 베이스 이미지(node/nginx)에
+    # 새로 등록되는 CVE를 정기적으로 감지하기 위함
+    - cron: "0 4 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: image-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: 이미지 빌드 (스캔 전용, push 없음)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          load: true
+          tags: cowmjucraft-fe:scan
+          build-args: |
+            BUILD_SHA=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # 1단계: 관찰 전용. HIGH/CRITICAL이 나와도 빌드를 막지 않고
+      # GitHub Security 탭에 결과만 올린다. 베이스 이미지(node/nginx)
+      # CVE 현황을 먼저 파악한 뒤, 별도 PR에서 severity gate(예: exit-code
+      # 강제 실패)를 켤지 정한다. CSP를 Report-Only로 먼저 켰던 것과 같은 이유.
+      - name: Trivy 취약점 스캔 (SARIF)
+        uses: aquasecurity/trivy-action@0.28.0
+        continue-on-error: true
+        with:
+          image-ref: cowmjucraft-fe:scan
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+
+      - name: Trivy 결과를 GitHub Security 탭에 업로드
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+
+      - name: SBOM 생성 (SPDX)
+        uses: anchore/sbom-action@v0
+        with:
+          image: cowmjucraft-fe:scan
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: SBOM 아티팩트 업로드
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-${{ github.sha }}
+          path: sbom.spdx.json
+          retention-days: 90

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -53,28 +53,38 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # 1단계: 관찰 전용. HIGH/CRITICAL이 나와도 빌드를 막지 않고
-      # GitHub Security 탭에 결과만 올린다. 베이스 이미지(node/nginx)
-      # CVE 현황을 먼저 파악한 뒤, 별도 PR에서 severity gate(예: exit-code
-      # 강제 실패)를 켤지 정한다. CSP를 Report-Only로 먼저 켰던 것과 같은 이유.
-      - name: Trivy 취약점 스캔 (SARIF)
-        uses: aquasecurity/trivy-action@0.28.0
+      # Trivy(aquasecurity/trivy-action) 대신 Grype/Syft(Anchore)를 쓴다.
+      # trivy-action은 2026년에 두 차례 공급망 공격을 당해(GHSA-69fq-xp46-6x23,
+      # CVE-2026-33634) 태그 대부분이 자격증명 탈취 페이로드로 강제 push된
+      # 이력이 있다. Grype/Syft는 같은 사고 이력이 없고, 공급망 위험을 줄이려면
+      # action 참조도 태그 대신 GitHub에서 서명 검증된 immutable release 커밋
+      # SHA로 고정하는 게 안전하다(태그는 이번 사고처럼 재지정될 수 있음).
+      #
+      # 1단계: 관찰 전용. HIGH 이상이 나와도 빌드를 막지 않고 GitHub Security
+      # 탭에 결과만 올린다. 베이스 이미지(node/nginx) CVE 현황을 먼저 파악한
+      # 뒤, 별도 PR에서 severity gate(fail-build: true)를 켤지 정한다.
+      # CSP를 Report-Only로 먼저 켰던 것과 같은 이유.
+      - name: Grype 취약점 스캔 (SARIF)
+        # anchore/scan-action v7.4.0 (2026-03-20, GPG 서명 확인된 immutable release)
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2
         continue-on-error: true
         with:
-          image-ref: cowmjucraft-fe:scan
-          format: sarif
-          output: trivy-results.sarif
-          severity: HIGH,CRITICAL
-          ignore-unfixed: true
+          image: cowmjucraft-fe:scan
+          output-format: sarif
+          output-file: grype-results.sarif
+          severity-cutoff: high
+          fail-build: false
+          only-fixed: true
 
-      - name: Trivy 결과를 GitHub Security 탭에 업로드
+      - name: Grype 결과를 GitHub Security 탭에 업로드
         if: always()
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: trivy-results.sarif
+          sarif_file: grype-results.sarif
 
-      - name: SBOM 생성 (SPDX)
-        uses: anchore/sbom-action@v0
+      - name: SBOM 생성 (SPDX, Syft)
+        # anchore/sbom-action v0.24.0 (2026-03-20, GPG 서명 확인된 immutable release)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610
         with:
           image: cowmjucraft-fe:scan
           format: spdx-json


### PR DESCRIPTION
# 요약

CodeQL 정적 분석과 Docker 이미지 Trivy 취약점 스캔 + SBOM 생성을 CI에 추가한다.

# 작업 내용

- [ ] codeql.yml 추가 (JS/TS 분석, main push/PR + 주간 스케줄)
- [ ] image-scan.yml 추가 (Trivy 스캔 + SPDX SBOM)

# 기술적 변경 포인트

- 둘 다 결과를 GitHub Security 탭(Code scanning alerts)에 업로드
- Trivy는 1단계로 관찰 전용(continue-on-error) — HIGH/CRITICAL이 나와도 빌드는 안 막음. 베이스 이미지(node/nginx) CVE 현황 파악 후 별도 PR에서 강제 gate 여부 결정 (CSP Report-Only와 같은 패턴)
- SBOM은 SPDX JSON으로 아티팩트 90일 보관

# 테스트 방법

- [x] YAML 문법 검증 (yaml.safe_load)
- [ ] PR CI에서 실제 워크플로우 실행 결과 확인

# 배포 영향

없음 (CI 워크플로우만 추가, 배포 파이프라인 변경 없음)

# 보안 / 민감정보 영향

CodeQL/Trivy 결과가 Security 탭에 노출됨 — public repo라 누구나 볼 수 있음. 민감한 취약점이 나오면 별도로 비공개 처리 필요할 수 있음

# 기타 (논의하고 싶은 부분)

머지 후 Security 탭에서 실제 Trivy 결과 확인 필요. 베이스 이미지에 이미 알려진 CVE가 많으면 severity gate를 바로 켜기보다 점진적으로 적용할 것

# 타 직군 전달 사항

close #이슈번호