### PR TITLE
test: Playwright 스모크 테스트 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,40 @@ jobs:
       - run: npm ci
       - run: npm test
 
+  e2e-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # 프로덕션 빌드(vite build/preview) 실행에 필요 — lint-build job과 같은 이유
+    env:
+      VITE_API_BASE_URL: https://api.mju-craft.shop/api
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Playwright 브라우저 설치
+        run: npx playwright install --with-deps chromium
+
+      - name: Build
+        run: npm run build
+
+      - name: Playwright 스모크 테스트
+        run: npm run test:e2e
+
+      - name: 테스트 리포트 업로드 (실패 시)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
   docker-build:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ dist-ssr
 
 # AI workspace
 .ai-workspace/
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,13 @@ AI는 아래 작업을 사용자 승인 없이 실행하지 않는다.
 - 깡통 테스트 금지 — assertion 없는 테스트, 구현 복사 테스트는 작성하지 않는다
 - 참고 예시: `src/api/client.test.ts` (fetch mock, 토큰 부착·에러 처리), `src/utils/date.test.ts` (경계값)
 
+**E2E 스모크 테스트**: `e2e/` 디렉토리에 Playwright로 작성한다 (`npm run test:e2e`).
+Vitest 단위 테스트와 대상이 다르다 — 개별 로직이 아니라 "빌드된 실제 페이지가
+크래시 없이 렌더링되는지"만 확인한다. 특정 데이터 내용에 의존하는 어서션은
+피하고, API 응답과 무관하게 항상 렌더링되는 요소(레이아웃, 폼, 리다이렉트)만
+검증한다. `vitest.config.ts`의 `test.exclude`에 `e2e/**`가 포함돼 있어야
+vitest가 Playwright 스펙 파일을 잘못 주워가지 않는다.
+
 ---
 
 ## 핸드오프/상태 문서 컨벤션

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+
+// 스모크 테스트: 배포 전에 "화면이 아예 안 뜨는" 수준의 회귀를 잡기 위한
+// 최소한의 테스트. react/react-dom 버전 불일치로 화면이 백지가 됐던
+// 사고(2026-07) 같은 걸 배포 전에 잡아내는 게 목적이라, 특정 데이터
+// 내용이 아니라 "핵심 라우트가 렌더링되는지"만 확인한다.
+
+test.describe('스모크: 핵심 라우트 렌더링', () => {
+  test('메인 페이지가 렌더링되고 푸터가 보인다', async ({ page }) => {
+    await page.goto('/');
+
+    // 공지/프로젝트 데이터 유무와 무관하게 항상 렌더링되는 footer 텍스트로 확인
+    await expect(
+      page.getByText('명지공방 MJU Craft Studio'),
+    ).toBeVisible();
+  });
+
+  test('로그인 페이지가 렌더링된다', async ({ page }) => {
+    await page.goto('/login');
+
+    await expect(
+      page.getByRole('heading', { name: '관리자 로그인' }),
+    ).toBeVisible();
+    await expect(page.getByPlaceholder('아이디를 입력해주세요.')).toBeVisible();
+    await expect(
+      page.getByPlaceholder('비밀번호를 입력해주세요.'),
+    ).toBeVisible();
+  });
+
+  test('로그인 없이 관리자 페이지 접근 시 로그인 페이지로 리다이렉트된다', async ({
+    page,
+  }) => {
+    await page.goto('/admin');
+
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(
+      page.getByRole('heading', { name: '관리자 로그인' }),
+    ).toBeVisible();
+  });
+
+  test('프로젝트 목록 페이지가 렌더링된다', async ({ page }) => {
+    await page.goto('/projects');
+
+    // 로딩/에러/빈 목록 어떤 상태든 페이지 자체는 크래시 없이 떠야 한다
+    await expect(
+      page.getByText('명지공방 MJU Craft Studio'),
+    ).toBeVisible();
+  });
+});

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -19,7 +19,7 @@ test.describe('스모크: 핵심 라우트 렌더링', () => {
     await page.goto('/login');
 
     await expect(
-      page.getByRole('heading', { name: '관리자 로그인' }),
+      page.getByRole('heading', { name: '관리자 로그인', level: 1 }),
     ).toBeVisible();
     await expect(page.getByPlaceholder('아이디를 입력해주세요.')).toBeVisible();
     await expect(
@@ -34,7 +34,7 @@ test.describe('스모크: 핵심 라우트 렌더링', () => {
 
     await expect(page).toHaveURL(/\/login$/);
     await expect(
-      page.getByRole('heading', { name: '관리자 로그인' }),
+      page.getByRole('heading', { name: '관리자 로그인', level: 1 }),
     ).toBeVisible();
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.5",
+        "@playwright/test": "1.61.1",
         "@tailwindcss/vite": "^4.3.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1334,6 +1335,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -5921,6 +5938,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -28,6 +29,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.5",
+    "@playwright/test": "1.61.1",
     "@tailwindcss/vite": "^4.3.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// 스모크 테스트: 빌드된 프로덕션 번들을 `vite preview`로 띄워서
+// 핵심 라우트가 실제로 렌더링되는지만 확인한다. 데이터 유무에 좌우되는
+// 어서션(공지/프로젝트 목록 내용 등)은 피하고, API 응답과 무관하게
+// 항상 렌더링되는 레이아웃 요소(footer, 로그인 폼, 관리자 리다이렉트)만 검증한다.
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  timeout: 30_000,
+
+  use: {
+    baseURL: 'http://localhost:4173',
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: 'npm run preview -- --port 4173',
+    url: 'http://localhost:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,5 +7,8 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
+    // e2e/는 Playwright 전용 테스트라 vitest가 같이 주워서 돌리면
+    // test.describe()가 Playwright API로 인식되지 않아 깨진다.
+    exclude: ['node_modules/**', 'dist/**', 'e2e/**'],
   },
 });


### PR DESCRIPTION
# 요약

배포 전 "화면이 아예 안 뜨는" 수준의 회귀를 잡기 위한 Playwright 스모크 테스트를 추가한다.

# 작업 내용

- [ ] @playwright/test 추가, playwright.config.ts 작성
- [ ] e2e/smoke.spec.ts: 메인/로그인/프로젝트 목록 렌더링 + 미인증 관리자 리다이렉트
- [ ] ci.yml에 e2e-smoke job 추가

# 기술적 변경 포인트

- 데이터 내용이 아니라 API 응답과 무관하게 항상 뜨는 요소(footer, 로그인 폼, 리다이렉트)만 검증 — react/react-dom 버전 불일치로 화면이 백지가 됐던 사고(2026-07) 같은 걸 배포 전에 잡는 게 목적
- vitest.config.ts에 `exclude: ['e2e/**']` 추가 필요 — 안 하면 vitest가 Playwright 스펙을 자기 테스트로 오인해서 깨짐 (로컬 검증 중 발견)
- e2e-smoke job은 lint-build job과 같은 이유로 VITE_API_BASE_URL이 필요 (build+preview)

# 테스트 방법

- [x] `npm run lint`
- [x] `npx tsc -b`
- [x] `npm test` (vitest, e2e 제외 확인)
- [x] `npm run build`
- [ ] CI에서 실제 Playwright 브라우저 테스트 통과 확인 (샌드박스에 root 권한이 없어 로컬에서 브라우저 실행 자체는 검증 못 함)

# 배포 영향

없음 (테스트/CI 추가만, 런타임 코드 변경 없음)

# 보안 / 민감정보 영향

없음

# 기타 (논의하고 싶은 부분)

CI에서 실제로 브라우저 스모크 테스트가 통과하는지 첫 실행 결과 확인 필요

# 타 직군 전달 사항

close #이슈번호