### PR TITLE
feat: 액세스 토큰 만료 시 자동 재발급 및 요청 재시도

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -9,6 +9,9 @@ export type AdminLoginResponse = {
   loginId: string;
   email: string;
   accessToken: string;
+  accessTokenExpiresInSeconds: number;
+  refreshToken: string;
+  refreshTokenExpiresInSeconds: number;
 };
 
 export type UpdateAccountBody = {

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -4,10 +4,17 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 vi.mock('../utils/auth', () => ({
   clearAuth: vi.fn(),
   getAccessToken: vi.fn(() => null),
+  getRefreshToken: vi.fn(() => null),
+  updateTokens: vi.fn(),
 }));
 
 import { api, ApiError, withApiBase } from './client';
-import { clearAuth, getAccessToken } from '../utils/auth';
+import {
+  clearAuth,
+  getAccessToken,
+  getRefreshToken,
+  updateTokens,
+} from '../utils/auth';
 
 function mockFetch(status: number, body: unknown) {
   return vi.fn().mockResolvedValue(
@@ -21,6 +28,7 @@ function mockFetch(status: number, body: unknown) {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getAccessToken).mockReturnValue(null);
+  vi.mocked(getRefreshToken).mockReturnValue(null);
 });
 
 afterEach(() => {
@@ -66,7 +74,7 @@ describe('api', () => {
     expect((err as ApiError).message).toBe('없음');
   });
 
-  it('401이면 clearAuth를 호출한다', async () => {
+  it('401이고 refresh token이 없으면 clearAuth를 호출한다', async () => {
     vi.stubGlobal('fetch', mockFetch(401, { message: 'unauthorized' }));
 
     await expect(api('/x')).rejects.toBeInstanceOf(ApiError);
@@ -90,5 +98,122 @@ describe('api', () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 204 })));
 
     await expect(api('/x')).resolves.toBeUndefined();
+  });
+});
+
+describe('api 토큰 재발급', () => {
+  function jsonResponse(status: number, body: unknown) {
+    return new Response(body === undefined ? null : JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  function envelope(data: unknown) {
+    return { resultType: 'SUCCESS', httpStatusCode: 200, message: 'ok', data };
+  }
+
+  function loggedInWithRefreshToken() {
+    vi.mocked(getAccessToken).mockReturnValue('expired-token');
+    vi.mocked(getRefreshToken).mockReturnValue('ref123');
+  }
+
+  it('401이면 재발급 후 원래 요청을 재시도한다', async () => {
+    loggedInWithRefreshToken();
+    const f = vi
+      .fn()
+      // 1) 원요청 401
+      .mockResolvedValueOnce(jsonResponse(401, { message: 'expired' }))
+      // 2) 재발급 성공
+      .mockResolvedValueOnce(
+        jsonResponse(200, envelope({ accessToken: 'new-tok', refreshToken: 'new-ref' })),
+      )
+      // 3) 재시도 성공
+      .mockResolvedValueOnce(jsonResponse(200, envelope({ id: 1 })));
+    vi.stubGlobal('fetch', f);
+
+    await expect(api('/admin/orders')).resolves.toEqual({ id: 1 });
+
+    expect(f).toHaveBeenCalledTimes(3);
+    expect(updateTokens).toHaveBeenCalledWith({
+      accessToken: 'new-tok',
+      refreshToken: 'new-ref',
+    });
+    expect(clearAuth).not.toHaveBeenCalled();
+  });
+
+  it('재발급이 실패하면 clearAuth 후 원래 오류를 던진다', async () => {
+    loggedInWithRefreshToken();
+    const f = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(401, { message: 'expired' }))
+      // 재발급도 401
+      .mockResolvedValueOnce(jsonResponse(401, { message: 'invalid refresh token' }));
+    vi.stubGlobal('fetch', f);
+
+    const err = await api('/admin/orders').catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(401);
+    expect(clearAuth).toHaveBeenCalledOnce();
+    expect(updateTokens).not.toHaveBeenCalled();
+  });
+
+  it('재시도도 401이면 더 재발급하지 않고 clearAuth한다', async () => {
+    loggedInWithRefreshToken();
+    const f = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(401, { message: 'expired' }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, envelope({ accessToken: 'new-tok', refreshToken: 'new-ref' })),
+      )
+      // 재시도마저 401 — 무한 루프로 가면 안 된다
+      .mockResolvedValueOnce(jsonResponse(401, { message: 'still unauthorized' }));
+    vi.stubGlobal('fetch', f);
+
+    await expect(api('/admin/orders')).rejects.toBeInstanceOf(ApiError);
+
+    expect(f).toHaveBeenCalledTimes(3);
+    expect(clearAuth).toHaveBeenCalledOnce();
+  });
+
+  it('동시에 401을 받아도 재발급은 한 번만 호출한다', async () => {
+    loggedInWithRefreshToken();
+    const f = vi.fn().mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.endsWith('/admin/refresh')) {
+        return Promise.resolve(
+          jsonResponse(200, envelope({ accessToken: 'new-tok', refreshToken: 'new-ref' })),
+        );
+      }
+      // 첫 호출은 401, 재시도는 성공
+      return Promise.resolve(
+        f.mock.calls.filter((c) => !String(c[0]).endsWith('/admin/refresh')).length <= 3
+          ? jsonResponse(401, { message: 'expired' })
+          : jsonResponse(200, envelope({ ok: true })),
+      );
+    });
+    vi.stubGlobal('fetch', f);
+
+    await Promise.allSettled([api('/admin/a'), api('/admin/b'), api('/admin/c')]);
+
+    const refreshCalls = f.mock.calls.filter((c) =>
+      String(c[0]).endsWith('/admin/refresh'),
+    );
+    expect(refreshCalls).toHaveLength(1);
+  });
+
+  it('Authorization 헤더가 없던 요청의 401은 재발급하지 않는다', async () => {
+    // 비회원 주문 조회의 비밀번호 불일치 — 재발급으로 해결되지 않는다
+    vi.mocked(getAccessToken).mockReturnValue(null);
+    vi.mocked(getRefreshToken).mockReturnValue('ref123');
+    const f = vi.fn().mockResolvedValue(jsonResponse(401, { message: '비밀번호 불일치' }));
+    vi.stubGlobal('fetch', f);
+
+    await expect(api('/orders/lookup', { method: 'POST', body: {} })).rejects.toBeInstanceOf(
+      ApiError,
+    );
+
+    expect(f).toHaveBeenCalledOnce();
+    expect(updateTokens).not.toHaveBeenCalled();
   });
 });

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,9 @@
-﻿import { clearAuth, getAccessToken } from "../utils/auth";
+﻿import {
+  clearAuth,
+  getAccessToken,
+  getRefreshToken,
+  updateTokens,
+} from "../utils/auth";
 
 type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 
@@ -35,9 +40,68 @@ type ApiEnvelope<T> = {
   data: T | null;
 };
 
+export const REFRESH_PATH = "/admin/refresh";
+
+// 동시에 여러 요청이 401을 받아도 재발급은 한 번만 수행하고,
+// 나머지는 그 결과를 함께 기다린다.
+let refreshPromise: Promise<boolean> | null = null;
+
+async function refreshAccessToken(): Promise<boolean> {
+  const refreshToken = getRefreshToken();
+  if (!refreshToken) return false;
+
+  // api()를 거치면 재발급 응답의 401이 다시 재발급을 부르므로 fetch를 직접 쓴다.
+  try {
+    const res = await fetch(withApiBase(REFRESH_PATH), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken }),
+      credentials: "include",
+    });
+
+    if (!res.ok) return false;
+
+    const text = await res.text();
+    const parsed: unknown = text ? safeJsonParse(text) : null;
+    const payload = isApiEnvelope(parsed) ? parsed.data : parsed;
+
+    if (!payload || typeof payload !== "object") return false;
+
+    const record = payload as Record<string, unknown>;
+    const accessToken = record["accessToken"];
+    if (typeof accessToken !== "string" || !accessToken) return false;
+
+    const nextRefreshToken = record["refreshToken"];
+    updateTokens({
+      accessToken,
+      // 회전형이므로 새 refresh token이 함께 온다
+      refreshToken:
+        typeof nextRefreshToken === "string" ? nextRefreshToken : null,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function refreshOnce(): Promise<boolean> {
+  refreshPromise ??= refreshAccessToken().finally(() => {
+    refreshPromise = null;
+  });
+  return refreshPromise;
+}
+
 export async function api<T>(
   path: string,
   opts: RequestOptions = {},
+): Promise<T> {
+  return request<T>(path, opts, true);
+}
+
+async function request<T>(
+  path: string,
+  opts: RequestOptions,
+  allowRefresh: boolean,
 ): Promise<T> {
   const method = opts.method ?? "GET";
 
@@ -65,6 +129,19 @@ export async function api<T>(
 
   if (!res.ok) {
     if (res.status === 401) {
+      // 인증이 걸린 요청만 재발급 대상이다. 비회원 조회 API의 401(비밀번호 불일치)은
+      // 재발급으로 해결되지 않으므로 Authorization 헤더가 있었는지로 구분한다.
+      const canRefresh =
+        allowRefresh &&
+        Boolean(token) &&
+        !path.endsWith(REFRESH_PATH) &&
+        Boolean(getRefreshToken());
+
+      if (canRefresh && (await refreshOnce())) {
+        // 재발급 성공 — 새 토큰으로 한 번만 재시도한다
+        return request<T>(path, opts, false);
+      }
+
       clearAuth();
     }
     let msg = extractErrorMessage(data);

--- a/src/pages/site/LoginPage.tsx
+++ b/src/pages/site/LoginPage.tsx
@@ -9,6 +9,7 @@ type SubmitStatus = 'idle' | 'submitting' | 'success' | 'error';
 
 type AdminLoginResponse = {
   accessToken?: string;
+  refreshToken?: string;
   loginId?: string;
 };
 
@@ -90,7 +91,11 @@ export default function LoginPage() {
       }
 
       const name = (result.loginId ?? userId.trim()).trim() || 'USER';
-      setAuth({ accessToken: result.accessToken, userName: name });
+      setAuth({
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        userName: name,
+      });
 
       setStatus('success');
       navigate('/admin', { replace: true });

--- a/src/utils/auth.test.ts
+++ b/src/utils/auth.test.ts
@@ -3,9 +3,11 @@ import {
   AUTH_CHANGED_EVENT,
   clearAuth,
   getAccessToken,
+  getRefreshToken,
   getUserName,
   isLoggedIn,
   setAuth,
+  updateTokens,
 } from './auth';
 
 beforeEach(() => {
@@ -58,5 +60,39 @@ describe('auth', () => {
 
     expect(getAccessToken()).toBe('tok456');
     expect(getUserName()).toBeNull();
+  });
+
+  it('setAuth는 refreshToken도 sessionStorage에 저장한다', () => {
+    setAuth({ accessToken: 'tok123', refreshToken: 'ref123', userName: '홍길동' });
+
+    expect(getRefreshToken()).toBe('ref123');
+    expect(sessionStorage.getItem('refreshToken')).toBe('ref123');
+    expect(localStorage.length).toBe(0);
+  });
+
+  it('clearAuth는 refreshToken도 지운다', () => {
+    setAuth({ accessToken: 'tok123', refreshToken: 'ref123' });
+    clearAuth();
+
+    expect(getRefreshToken()).toBeNull();
+  });
+
+  it('updateTokens는 토큰만 교체하고 userName은 유지한다', () => {
+    setAuth({ accessToken: 'tok123', refreshToken: 'ref123', userName: '홍길동' });
+
+    updateTokens({ accessToken: 'tok456', refreshToken: 'ref456' });
+
+    expect(getAccessToken()).toBe('tok456');
+    expect(getRefreshToken()).toBe('ref456');
+    expect(getUserName()).toBe('홍길동');
+  });
+
+  it('updateTokens에 refreshToken이 없으면 기존 값을 유지한다', () => {
+    setAuth({ accessToken: 'tok123', refreshToken: 'ref123' });
+
+    updateTokens({ accessToken: 'tok456' });
+
+    expect(getAccessToken()).toBe('tok456');
+    expect(getRefreshToken()).toBe('ref123');
   });
 });

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,4 +1,5 @@
 const TOKEN_KEY = import.meta.env.VITE_TOKEN_KEY ?? 'accessToken';
+const REFRESH_TOKEN_KEY = 'refreshToken';
 const USER_NAME_KEY = 'userName';
 
 // 토큰 get/set/clear는 반드시 이 모듈을 통해서만 접근한다.
@@ -11,6 +12,16 @@ export const AUTH_CHANGED_EVENT = 'auth-changed';
 export function getAccessToken(): string | null {
   try {
     return sessionStorage.getItem(TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+// 액세스 토큰이 만료됐을 때 재발급에 사용한다. 액세스 토큰과 같은 sessionStorage
+// 정책을 따르므로 탭을 닫으면 함께 사라진다.
+export function getRefreshToken(): string | null {
+  try {
+    return sessionStorage.getItem(REFRESH_TOKEN_KEY);
   } catch {
     return null;
   }
@@ -32,10 +43,16 @@ export function isLoggedIn(): boolean {
 
 export function setAuth(payload: {
   accessToken: string;
+  refreshToken?: string | null;
   userName?: string | null;
 }) {
   try {
     sessionStorage.setItem(TOKEN_KEY, payload.accessToken);
+
+    if (payload.refreshToken && payload.refreshToken.trim()) {
+      sessionStorage.setItem(REFRESH_TOKEN_KEY, payload.refreshToken.trim());
+    }
+
     if (payload.userName && payload.userName.trim()) {
       sessionStorage.setItem(USER_NAME_KEY, payload.userName.trim());
     } else {
@@ -46,9 +63,26 @@ export function setAuth(payload: {
   }
 }
 
+// 토큰 재발급으로 액세스/리프레시 토큰만 교체한다.
+// userName은 건드리지 않는다 — 재발급은 사용자 정보와 무관하다.
+export function updateTokens(payload: {
+  accessToken: string;
+  refreshToken?: string | null;
+}) {
+  try {
+    sessionStorage.setItem(TOKEN_KEY, payload.accessToken);
+    if (payload.refreshToken && payload.refreshToken.trim()) {
+      sessionStorage.setItem(REFRESH_TOKEN_KEY, payload.refreshToken.trim());
+    }
+  } catch {
+    // sessionStorage 접근 불가 환경에서는 재발급 결과를 보관하지 않는다
+  }
+}
+
 export function clearAuth() {
   try {
     sessionStorage.removeItem(TOKEN_KEY);
+    sessionStorage.removeItem(REFRESH_TOKEN_KEY);
     sessionStorage.removeItem(USER_NAME_KEY);
   } finally {
     window.dispatchEvent(new Event(AUTH_CHANGED_EVENT));


### PR DESCRIPTION
# 요약

액세스 토큰이 만료되면 자동으로 재발급받아 원래 요청을 재시도하도록 해서, 관리자가 로그인 1시간 뒤 작업 중에 로그아웃되던 문제를 없앱니다.

# 작업 내용

- [x] `auth.ts`에 refresh token 저장·조회 추가 (`getRefreshToken`, `setAuth`의 `refreshToken` 파라미터)
- [x] `updateTokens()` 신설 — 재발급 시 토큰만 교체하고 `userName`은 유지
- [x] `clearAuth()`가 refresh token도 함께 삭제
- [x] `client.ts`에서 401 수신 시 재발급 후 원요청 재시도
- [x] 재시도 1회 제한 (무한 루프 방지)
- [x] 동시 401 요청에 대한 단일 비행(single-flight) 처리 — 재발급은 한 번만
- [x] `AdminLoginResponse` 타입에 `refreshToken`, 만료 초 필드 추가
- [x] 로그인 시 refresh token 저장 (`LoginPage`)
- [x] 테스트 10건 추가 (auth 4, client 6)

# 기술적 변경 포인트

**재발급 호출이 `api()`를 거치지 않습니다.** `client.ts` 안에서 `fetch`를 직접 씁니다. `api()`를 쓰면 재발급 응답의 401이 다시 재발급을 호출하는 순환이 생깁니다.

**단일 비행 처리.** 모듈 레벨 `refreshPromise`로 동시에 401을 받은 요청들이 같은 재발급 결과를 기다립니다. 대시보드처럼 여러 API를 병렬 호출하는 화면에서 재발급이 중복 호출되면 회전형 토큰이 서로를 무효화시킵니다.

**재발급 대상 판별.** `Authorization` 헤더가 실렸던 요청의 401만 재발급합니다. 비회원 주문 조회(`/orders/lookup`)의 401은 비밀번호 불일치라 재발급으로 해결되지 않기 때문입니다. 테스트로 고정해뒀습니다.

**회전형 대응.** `/admin/refresh` 응답에 새 액세스 토큰과 **새 refresh token이 함께** 오므로 둘 다 갱신합니다.

# 테스트 방법

- [x] `npm run lint` — 통과
- [x] `npm run build` — 통과 (`VITE_API_BASE_URL` 더미값 주입)
- [x] `npm test` — 35개 전부 통과

> ⚠️ 로컬 Node 24 이상에서는 `npm test`가 `localStorage` 관련으로 실패할 수 있습니다. **이 PR과 무관한 기존 문제**로, main에서도 동일하게 12건 실패합니다.
>
> 원인은 Node 24+부터 내장 `localStorage` 전역이 기본 활성화되면서 jsdom의 것을 가리는 것입니다(`--localstorage-file` 미지정 시 `undefined`). `sessionStorage`는 정상인데 `localStorage`만 깨지는 이유입니다.
>
> **CI는 Node 22를 쓰므로 영향받지 않습니다.** 로컬 검증은 임시 shim을 적용해 수행했고, 해당 파일은 커밋에 포함하지 않았습니다.

**수동 확인 권장 시나리오**

1. 관리자 로그인 → sessionStorage에 `accessToken`, `refreshToken`이 모두 저장되는지
2. `accessToken`을 임의의 잘못된 값으로 바꾼 뒤 관리자 화면 조작 → 자동 재발급 후 정상 동작하는지
3. `refreshToken`까지 잘못된 값으로 바꾼 뒤 조작 → 로그인 화면으로 정상 이동하는지
4. 관리자 대시보드처럼 API를 여러 개 호출하는 화면에서 만료 상황 → 네트워크 탭에 `/admin/refresh`가 **한 번만** 찍히는지
5. 로그아웃 → `refreshToken`도 함께 지워지는지

# 배포 영향

없습니다. 환경 변수 추가·변경 없고 의존성도 그대로입니다.

# 보안 / 민감정보 영향

**refresh token이 sessionStorage에 저장됩니다.** 기존 액세스 토큰과 동일한 정책이라 탭을 닫으면 함께 사라집니다. 저장 위치를 더 안전한 방식(httpOnly 쿠키 등)으로 바꾸려면 서버 변경이 함께 필요해 이번 범위에서는 제외했습니다.

**로그아웃 시 refresh token도 삭제**되도록 했습니다. 기존에는 저장 자체를 안 했으니 신규 동작입니다.

# 기타 (논의하고 싶은 부분)

**⚠️ 머지 순서**

이 PR이 머지되면 프런트가 refresh를 실제로 사용하기 시작합니다. 백엔드 쪽에 refresh 토큰 동시 사용 관련 보완 작업이 예정되어 있어, **그 작업이 먼저 배포된 뒤 이 PR을 머지**하는 것을 권합니다. 백엔드 담당자와 순서를 맞춰주세요.

**후속 예정**

이 PR이 안정적으로 동작하는 것이 확인되면 백엔드에서 액세스 토큰 수명을 1시간에서 15분 수준으로 줄일 예정입니다. 재시도 로직이 잦은 만료 상황에서도 잘 버티는지 봐주시면 좋겠습니다.

# 타 직군 전달 사항

백엔드 변경은 필요 없습니다. 기존 `/api/admin/refresh` 엔드포인트를 그대로 사용합니다.

close #204
