### PR TITLE
chore: 패치 경로 없는 취약점 권고를 사유와 함께 예외 처리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # 패치 경로가 없는 권고는 scripts/audit-gate.js의 ALLOWLIST에서 사유와 함께 관리한다.
       - name: npm audit (high 이상 취약점 gate)
-        run: npm audit --audit-level=high
+        run: node scripts/audit-gate.js
 
   test:
     runs-on: ubuntu-latest

--- a/scripts/audit-gate.js
+++ b/scripts/audit-gate.js
@@ -1,0 +1,95 @@
+// npm audit 게이트.
+//
+// `npm audit`은 개별 권고 예외를 지원하지 않아, 패치 경로가 없는 권고 하나 때문에
+// 게이트 전체를 끄거나 문턱을 낮추게 된다. 그러면 이후에 들어올 진짜 취약점을 놓친다.
+// 그래서 --json 결과에서 허용 목록만 걸러내고 나머지 high 이상은 그대로 실패시킨다.
+//
+// ALLOWLIST에 항목을 추가할 때는 반드시 "왜 해당 없는지"와 "언제 제거할지"를 함께 적는다.
+
+import { spawnSync } from 'node:child_process';
+
+const FAIL_LEVELS = new Set(['high', 'critical']);
+
+const ALLOWLIST = new Map([
+  [
+    'GHSA-qwww-vcr4-c8h2',
+    'react-router RSC Mode CSRF — 이 앱은 BrowserRouter 기반 Vite SPA라 RSC 라우트가 없어 해당 없음. ' +
+      'react-router-dom이 react-router를 정확한 버전으로 고정하고 8.x가 없어 패치 경로가 막혀 있다. ' +
+      '7.x 백포트가 나오면 제거할 것.',
+  ],
+  [
+    'GHSA-mh99-v99m-4gvg',
+    'brace-expansion DoS — eslint > minimatch@3 경유 개발 의존성이라 런타임 번들에 포함되지 않는다. ' +
+      'minimatch@3이 ^1.1.7을 요구하는데 1.x에는 패치 릴리스가 없다. ' +
+      'eslint가 minimatch를 올리면 제거할 것.',
+  ],
+]);
+
+const result = spawnSync('npm', ['audit', '--json'], {
+  encoding: 'utf8',
+  maxBuffer: 32 * 1024 * 1024,
+});
+
+// npm audit은 취약점이 있으면 종료 코드가 0이 아니므로, 코드가 아니라 출력 유무로 판단한다.
+if (!result.stdout) {
+  console.error('npm audit 실행 실패');
+  if (result.stderr) console.error(result.stderr);
+  process.exit(1);
+}
+
+let report;
+try {
+  report = JSON.parse(result.stdout);
+} catch {
+  console.error('npm audit JSON 파싱 실패. 원본 출력 앞부분:');
+  console.error(result.stdout.slice(0, 2000));
+  process.exit(1);
+}
+
+// via 배열의 객체 항목만 실제 권고다. 문자열 항목은 다른 패키지를 통해 전파된
+// 결과라서 중복으로 세지 않는다.
+const advisories = new Map();
+for (const vulnerability of Object.values(report.vulnerabilities ?? {})) {
+  for (const via of vulnerability.via ?? []) {
+    if (typeof via !== 'object' || !via.url) continue;
+    const id = via.url.split('/').pop();
+    advisories.set(id, {
+      id,
+      name: via.name,
+      severity: via.severity,
+      title: via.title,
+      url: via.url,
+    });
+  }
+}
+
+const blocking = [];
+const allowed = [];
+for (const advisory of advisories.values()) {
+  if (!FAIL_LEVELS.has(advisory.severity)) continue;
+  (ALLOWLIST.has(advisory.id) ? allowed : blocking).push(advisory);
+}
+
+for (const advisory of allowed) {
+  console.log(`허용됨    ${advisory.id}  ${advisory.name}`);
+  console.log(`          ${ALLOWLIST.get(advisory.id)}`);
+}
+
+// 해결된 권고를 허용 목록에 남겨두면 나중에 같은 ID의 새 문제를 가린다.
+for (const id of ALLOWLIST.keys()) {
+  if (!advisories.has(id)) {
+    console.log(`정리 필요  ${id} — 더 이상 보고되지 않는다. ALLOWLIST에서 제거할 것.`);
+  }
+}
+
+if (blocking.length === 0) {
+  console.log(`\nhigh 이상 차단 대상 없음 (허용 ${allowed.length}건).`);
+  process.exit(0);
+}
+
+console.error(`\nhigh 이상 취약점 ${blocking.length}건 — 허용 목록에 없음:`);
+for (const advisory of blocking) {
+  console.error(`  ${advisory.severity.padEnd(8)} ${advisory.name}  ${advisory.title ?? ''}`);
+  console.error(`           ${advisory.url}`);
+}
+process.exit(1);


### PR DESCRIPTION
# 요약

패치 경로가 없는 취약점 권고 2건 때문에 `dependency-audit`이 실패하고, 그 여파로 **FE 배포가 통째로 막혀 있는 문제**를 해소한다.

# 작업 내용

- [x] `scripts/audit-gate.js` 추가 — `npm audit --json`을 파싱해 허용 목록만 걸러내는 게이트 (새 의존성 없음)
- [x] `ci.yml`의 `dependency-audit` 스텝을 이 스크립트 호출로 교체

# 기술적 변경 포인트

`main`의 CI가 `dependency-audit`에서 실패하면서 `deploy.yml`의 `if: workflow_run.conclusion == 'success'` 조건에 걸려 **배포 잡이 skip 되고 있었다.** #205(토큰 재발급)가 머지됐지만 운영에 반영되지 않은 상태다.

막고 있던 권고 2건 모두 패치 경로가 없다.

| 권고 | 경로 | 왜 패치할 수 없는가 |
|---|---|---|
| `GHSA-qwww-vcr4-c8h2` react-router | **런타임** | `react-router-dom@7.18.1`이 `react-router@7.18.1`을 정확히 고정. `react-router-dom`에 8.x가 없어 패치된 `react-router@8.3.0`으로 갈 수 없다 |
| `GHSA-mh99-v99m-4gvg` brace-expansion | **개발 전용** | `eslint → minimatch@3.1.5 → brace-expansion@1.1.16`. `minimatch@3`이 `^1.1.7`을 요구하는데 1.x에 패치 릴리스가 없다 (1.1.16이 마지막) |

두 권고 모두 이 앱에는 해당하지 않는다.

- react-router 권고는 **RSC 모드 전용**인데, 이 앱은 `src/main.tsx`의 `BrowserRouter` 기반 Vite SPA라 해당 코드 경로가 없다
- brace-expansion은 `npm audit --omit=dev`로 확인 시 런타임 트리에 나타나지 않는다 (`typescript-eslint` 쪽 경로는 이미 5.0.8로 안전)

게이트를 끄거나 `--audit-level=critical`로 문턱을 올리는 대신 **해당 권고 ID만 사유와 함께 예외 처리**했다. 그래야 앞으로 들어올 다른 high를 계속 잡는다. 허용 항목이 더 이상 보고되지 않으면 "정리 필요"를 출력해, 목록이 썩어서 새 취약점을 가리는 것을 막는다.

`audit-ci` 도입도 검토했으나 `event-stream` 포함 9개 의존성을 끌어와서, 보안 게이트 도구가 공급망 표면을 늘리는 것이 맞지 않다고 판단해 채택하지 않았다.

# 테스트 방법

- [x] `npm run lint` — 통과
- [x] `npm run build` — 통과
- [ ] `npm test` — 로컬 17건 실패하나 **본 변경과 무관**. Node 25의 네이티브 `localStorage`가 jsdom을 가려 `localStorage.clear is not a function`(16건), 로컬 `.env`의 `VITE_API_BASE_URL` 주입(1건)이 원인. CI(Node 22, `.env` 없음)에서는 같은 커밋 `467984f`에서 `test` 통과. 별도 이슈로 분리 예정

추가 검증:

- `node scripts/audit-gate.js` → exit 0, 허용 2건 출력
- 허용 목록을 비운 사본으로 음성 테스트 → exit 1, 차단 2건 정확히 보고

# 배포 영향

**이 PR이 머지되어야 배포가 재개된다.** 환경 변수 변경 없음, Docker/Coolify 설정 변경 없음.

머지 후 확인 순서:
1. main CI 초록 → `Build & Push to ghcr.io` 실행 확인
2. Coolify 반영 후 관리자 로그인 → 1시간 이상 조작해도 세션 유지되는지 확인 (#205 재발급 동작)
3. 기존 로그인 세션은 1회 강제 로그아웃됨 (sessionStorage에 refreshToken 없음)

# 보안 / 민감정보 영향

취약점 게이트의 **탐지 범위는 좁아지지 않는다.** 허용한 2건 외 high/critical은 그대로 실패시킨다. 토큰·인증·클라이언트 노출 값 변경 없음.

# 의존성 변경 시 체크

- [x] `package.json` / `package-lock.json` 변경 없음 — 해당 없음

# 기타 (논의하고 싶은 부분)

- 봇 PR 6건도 전부 이 권고 하나로만 막혀 있어, 머지 후 `@dependabot rebase`하면 함께 풀린다
- #208(eslint-tooling)이 eslint를 올려 `minimatch`가 갱신되면 brace-expansion 예외는 불필요해진다. 그때 게이트가 "정리 필요"를 출력하므로 해당 항목을 제거하면 된다
