### PR TITLE
fix: Node 24+ 로컬 환경에서 테스트가 깨지는 문제 수정

### DIFF
--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -8,7 +8,7 @@ vi.mock('../utils/auth', () => ({
   updateTokens: vi.fn(),
 }));
 
-import { api, ApiError, withApiBase } from './client';
+import { api, ApiError } from './client';
 import {
   clearAuth,
   getAccessToken,
@@ -36,9 +36,29 @@ afterEach(() => {
 });
 
 describe('withApiBase', () => {
-  it('VITE_API_BASE_URL이 없으면 경로를 그대로 반환한다', () => {
-    // vitest 환경에서는 env 미설정 → API_BASE = ""
+  // API_BASE는 모듈 로드 시점에 import.meta.env로 확정되므로, 로컬 .env 값이
+  // 새어들어오면 결과가 달라진다. env를 명시적으로 stub한 뒤 모듈을 다시 로드해
+  // 실행 환경(.env 유무)과 무관하게 두 분기를 모두 검증한다.
+  async function loadWithApiBase(baseUrl: string) {
+    vi.resetModules();
+    vi.stubEnv('VITE_API_BASE_URL', baseUrl);
+    return (await import('./client')).withApiBase;
+  }
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('VITE_API_BASE_URL이 없으면 경로를 그대로 반환한다', async () => {
+    const withApiBase = await loadWithApiBase('');
+
     expect(withApiBase('/projects')).toBe('/projects');
+  });
+
+  it('VITE_API_BASE_URL이 있으면 앞에 붙이고 끝의 슬래시는 제거한다', async () => {
+    const withApiBase = await loadWithApiBase('https://api.example.com/api/');
+
+    expect(withApiBase('/projects')).toBe('https://api.example.com/api/projects');
   });
 });
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,32 @@
 import '@testing-library/jest-dom/vitest';
+
+// Node 22+는 웹 스토리지 전역(localStorage/sessionStorage)을 노출하고, Node 25부터는
+// 플래그 없이 기본 활성화된다. 반면 vitest의 jsdom 환경은 "이미 전역에 존재하는 키"를
+// jsdom 구현으로 덮어쓰지 않으므로(populateGlobal의 `k in global` 검사), 테스트는
+// jsdom Storage 대신 Node 네이티브 구현을 보게 된다.
+// 이때 --localstorage-file 없이 실행하면 네이티브 localStorage는 Storage 프로토타입조차
+// 없는 빈 객체라, localStorage.clear() 같은 호출이 전부 TypeError로 죽는다.
+// (네이티브 sessionStorage는 정상 동작하므로 건드리지 않는다.)
+// Node 22 CI에서는 전역이 없어 jsdom 구현이 그대로 쓰이므로 이 분기는 실행되지 않는다.
+function isUsableStorage(value: unknown): value is Storage {
+  return typeof (value as Storage | null | undefined)?.clear === 'function';
+}
+
+if (!isUsableStorage(globalThis.localStorage)) {
+  // vitest가 jsdom window를 전역으로 흡수한 뒤라 원본 window를 직접 참조할 수 없다.
+  // 같은 jsdom 문서 안에 iframe을 만들면 정상적인 Storage 인스턴스를 얻을 수 있다.
+  const frame = document.createElement('iframe');
+  document.body.appendChild(frame);
+  const jsdomLocalStorage = frame.contentWindow?.localStorage;
+  frame.remove();
+
+  if (!isUsableStorage(jsdomLocalStorage)) {
+    throw new Error('테스트 환경에서 jsdom localStorage를 확보하지 못했습니다.');
+  }
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: jsdomLocalStorage,
+    configurable: true,
+    writable: true,
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,14 @@ export default defineConfig({
     setupFiles: ['./src/test/setup.ts'],
     // e2e/는 Playwright 전용 테스트라 vitest가 같이 주워서 돌리면
     // test.describe()가 Playwright API로 인식되지 않아 깨진다.
-    exclude: ['node_modules/**', 'dist/**', 'e2e/**'],
+    // 루트 기준 패턴(`node_modules/**`)은 중첩된 체크아웃(git worktree 등)의
+    // node_modules를 거르지 못해 남의 테스트까지 끌어온다. `**/`로 위치를 열어둔다.
+    // 에이전트 도구가 레포 안에 만드는 worktree도 같은 이유로 제외한다.
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/e2e/**',
+      '**/.claude/worktrees/**',
+    ],
   },
 });


### PR DESCRIPTION
# 요약

Node 24 이상 로컬 환경에서 `npm test`가 17건 실패하던 문제를 고친다. CI(Node 22)에서는 통과해 방치돼 있었고, 그 결과 개발자가 변경 검증을 CI에만 의존하는 상태였다.

# 작업 내용

- [x] `src/test/setup.ts` — 사용 불가 상태의 `localStorage`를 jsdom 구현으로 교체 (16건)
- [x] `src/api/client.test.ts` — `withApiBase` 테스트를 로컬 `.env`와 무관하게 변경, 누락 분기 추가 (1건, 35 → 36 테스트)
- [x] `vitest.config.ts` — `exclude` 패턴이 중첩 체크아웃을 거르지 못하던 문제 수정

# 기술적 변경 포인트

**1. 스토리지 (16건)**

`localStorage.clear is not a function`으로 죽고 있었다. 원인은 Node의 전역이 jsdom을 "가리는" 것이 아니라, **vitest가 애초에 jsdom 것을 설치하지 않는 것**이다. `populateGlobal`이 아래와 같이 판단한다.

```js
if (k in global) return keysArray.includes(k);
```

이미 `globalThis`에 있는 키는 vitest의 하드코딩된 `KEYS` 목록에 있을 때만 jsdom 구현으로 전달되는데, `localStorage`/`sessionStorage`는 그 목록에 없다. Node 22부터 웹 스토리지 전역이 노출되고 25부터 기본 활성화되므로, 두 전역 모두 Node 네이티브가 그대로 남는다.

결정타는 네이티브 `localStorage`가 `--localstorage-file` 없이 뜨면 **`Storage` 프로토타입조차 없는 빈 객체**라는 점이다. 네이티브 `sessionStorage`는 정상 동작하는 `Storage`라서 `localStorage`만 깨졌다.

사용 불가일 때만(`clear`가 함수가 아닐 때) 교체하므로 Node 22 CI에서는 이 분기가 실행되지 않는다. jsdom `Storage` 인스턴스는 iframe에서 얻는다 — vitest가 jsdom window를 전역으로 흡수한 뒤라 원본 `window`를 직접 참조할 방법이 없다.

`NODE_OPTIONS=--no-experimental-webstorage`로 해결하는 방법도 있으나 채택하지 않았다. 인식하지 못하는 플래그가 `NODE_OPTIONS`에 있으면 Node가 기동 자체를 거부하므로, Node 22.4 미만 사용자는 `npm test`가 통째로 죽는다. 지금 방식은 어느 버전에서도 안전하다.

**2. `.env` 누수 (1건)**

`API_BASE`는 모듈 로드 시점에 `import.meta.env`로 확정되므로 `vi.stubEnv`만으로는 바꿀 수 없다. `resetModules` + `stubEnv` + 동적 재import로 바꿔 실행 환경과 무관하게 만들었다. 그 과정에서 검증되지 않던 분기(prefix 적용 + 끝 슬래시 제거)도 추가했다.

**3. `exclude` 패턴**

`['node_modules/**', ...]`는 루트 기준이라 중첩된 체크아웃(git worktree 등)의 `node_modules`를 거르지 못한다. 실제로 레포 안에 worktree가 있을 때 zod·jest-dom 등 **남의 테스트까지 수집해 179개 파일이 돌았다.** `**/`로 위치를 열고, 에이전트 도구가 만드는 worktree 경로도 제외했다.

# 테스트 방법

- [x] `npm run lint` — 통과
- [x] `npm run build` — 통과
- [x] `npm test` — **36건 전부 통과**

검증 범위:

| 조건 | 결과 |
|---|---|
| Node 25 + `.env` 있음 (기존 실패 조건) | 36 통과 |
| Node 25 + `.env` 없음 | 36 통과 |
| `setup.ts` 수정만 제거 | 16건 실패로 회귀 — 수정이 실제로 동작함을 확인 |
| 레포 내 worktree 존재 상태 | 4파일만 수집 (수정 전 179파일) |

**한계 — 실제 Node 22로는 검증하지 못했다.** 로컬에 Node 25.3.0만 설치돼 있다. 다만 교체 분기가 "사용 불가일 때만" 동작하므로 Node 22에서는 아예 실행되지 않는다.

# 배포 영향

없음. 테스트·설정 파일만 변경하며 `src/` 애플리케이션 코드와 번들 산출물은 그대로다.

# 보안 / 민감정보 영향

없음. `.env` 값을 커밋하지 않으며, 오히려 테스트가 로컬 `.env`에 의존하지 않도록 만든다.

# 의존성 변경 시 체크

- [x] `package.json` / `package-lock.json` 변경 없음 — 해당 없음

# 기타 (논의하고 싶은 부분)

`.nvmrc` 또는 `engines`로 Node 22를 고정하는 방안은 넣지 않았다. 원인이 환경 계층에서 해결돼 두 버전 모두 통과하므로, 버전 고정은 문제를 가리는 쪽에 가깝다고 판단했다.
